### PR TITLE
feat(cleanup): wire up sleep/lock hooks via renv/kctx watch subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ go install github.com/eficode/secure-handling-of-secrets/cmd/kctx@latest
 ### Shell setup (recommended — add once to `~/.bashrc` / `~/.zshrc`)
 
 ```bash
-eval "$(renv init)"
+eval "$(renv shell-init)"
 ```
 
 This installs a shell function so that `renv resolve` and `renv unload` modify the current shell without needing `eval` every time.
@@ -117,7 +117,7 @@ See [docs/renv.md](docs/renv.md) for the full reference including configuration,
 ### Shell setup (recommended — add once to `~/.bashrc` / `~/.zshrc`)
 
 ```bash
-source <(kctx shell-init)
+eval "$(kctx shell-init)"
 ```
 
 ### Usage

--- a/cmd/kctx/detach_unix.go
+++ b/cmd/kctx/detach_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package main
+
+import (
+	"log/slog"
+	"syscall"
+)
+
+// detachFromTerminal moves the process into a new session so it is no longer
+// a member of the calling shell's process group.  This prevents Ctrl+C
+// (SIGINT sent to the foreground process group) from killing the watcher.
+func detachFromTerminal() {
+	if _, err := syscall.Setsid(); err != nil {
+		// Setsid fails when the process is already a process-group leader,
+		// which can happen if the shell put the background job in its own
+		// group (job-control enabled).  That's fine — the goal is achieved.
+		slog.Debug("watch: setsid skipped", "reason", err)
+	}
+}

--- a/cmd/kctx/detach_windows.go
+++ b/cmd/kctx/detach_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package main
+
+// detachFromTerminal is a no-op on Windows; session management is handled
+// by the Windows console host and is not required for the watcher.
+func detachFromTerminal() {}

--- a/cmd/kctx/main.go
+++ b/cmd/kctx/main.go
@@ -261,6 +261,7 @@ On Linux, sleep and screen-lock events are detected via D-Bus (systemd-logind).
 On macOS, sleep is detected via timer drift; screen lock requires a launchd agent.
 On Windows, event hooks are not yet implemented.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			detachFromTerminal()
 			uid := fmt.Sprintf("%d", os.Getuid())
 			slog.Debug("starting kctx watcher", "uid", uid)
 

--- a/cmd/kctx/main.go
+++ b/cmd/kctx/main.go
@@ -245,10 +245,17 @@ fi
 func watchCmd(cfg *config.Config) *cobra.Command {
 	return &cobra.Command{
 		Use:   "watch",
-		Short: "Watch for sleep/lock events and clear cache (run in background by shell-init)",
-		Long: `Run in the background to clear the kubeconfig tmpfile and secret cache
+		Short: "Watch for sleep/lock events and manage kubeconfigs (run in background by shell-init)",
+		Long: `Run in the background to manage kubeconfig tmpfiles and the secret cache
 when the system sleeps or the screen is locked. Normally started automatically
 by shell-init.
+
+On lock: managed kubeconfig tmpfiles are removed and open shells are signalled
+to unset KUBECONFIG. The encrypted cache is kept so configs can be quickly
+re-resolved after unlock without re-entering passwords.
+
+On sleep: the encrypted cache is also cleared, requiring full re-authentication
+after wake.
 
 On Linux, sleep and screen-lock events are detected via D-Bus (systemd-logind).
 On macOS, sleep is detected via timer drift; screen lock requires a launchd agent.
@@ -258,17 +265,31 @@ On Windows, event hooks are not yet implemented.`,
 			slog.Debug("starting kctx watcher", "uid", uid)
 
 			hook := cleanup.New()
-			if err := hook.Register(func() error {
-				slog.Debug("cleanup: clearing kctx cache and managed kubeconfigs")
-				cache := secrets.NewCache()
-				_ = cache.Clear(uid)
+
+			// On lock: remove managed kubeconfig tmpfiles and unload KUBECONFIG.
+			// The cache is kept so configs can be re-resolved after unlock
+			// without re-entering passwords.
+			if err := hook.RegisterLock(func() error {
+				slog.Debug("cleanup: clearing managed kubeconfigs on lock")
 				kubeconfig.ClearManaged()
-				// Signal open shells to unset KUBECONFIG on their next prompt.
 				_ = kubeconfig.RequestUnload(uid)
 				return nil
 			}); err != nil {
-				return fmt.Errorf("registering cleanup hook: %w", err)
+				return fmt.Errorf("registering lock hook: %w", err)
 			}
+
+			// On sleep: clear the encrypted cache as well.
+			if err := hook.RegisterSleep(func() error {
+				slog.Debug("cleanup: clearing kctx cache and managed kubeconfigs on sleep")
+				cache := secrets.NewCache()
+				_ = cache.Clear(uid)
+				kubeconfig.ClearManaged()
+				_ = kubeconfig.RequestUnload(uid)
+				return nil
+			}); err != nil {
+				return fmt.Errorf("registering sleep hook: %w", err)
+			}
+
 			defer hook.Unregister()
 
 			sigCh := make(chan os.Signal, 1)

--- a/cmd/kctx/main.go
+++ b/cmd/kctx/main.go
@@ -219,6 +219,20 @@ kctx() {
   esac
 }
 
+# Unset KUBECONFIG when the watcher signals that sleep/lock occurred.
+_kctx_check_unload() {
+  local f="/dev/shm/kctx-${UID}-unload-requested"
+  [ -f "$f" ] || f="/tmp/kctx-${UID}-unload-requested"
+  [ -f "$f" ] || return 0
+  rm -f "$f" 2>/dev/null
+  eval "$(command kctx unload 2>/dev/null)" 2>/dev/null || true
+}
+if [ -n "${ZSH_VERSION:-}" ]; then
+  autoload -Uz add-zsh-hook 2>/dev/null && add-zsh-hook precmd _kctx_check_unload
+else
+  PROMPT_COMMAND="_kctx_check_unload${PROMPT_COMMAND:+; $PROMPT_COMMAND}"
+fi
+
 # Start the sleep/lock watcher once per shell session.
 if [ -z "${_KCTX_WATCH_PID:-}" ]; then
   command kctx watch &
@@ -249,6 +263,8 @@ On Windows, event hooks are not yet implemented.`,
 				cache := secrets.NewCache()
 				_ = cache.Clear(uid)
 				kubeconfig.ClearManaged()
+				// Signal open shells to unset KUBECONFIG on their next prompt.
+				_ = kubeconfig.RequestUnload(uid)
 				return nil
 			}); err != nil {
 				return fmt.Errorf("registering cleanup hook: %w", err)

--- a/cmd/kctx/main.go
+++ b/cmd/kctx/main.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 
+	"github.com/eficode/secure-handling-of-secrets/internal/cleanup"
 	"github.com/eficode/secure-handling-of-secrets/internal/config"
 	"github.com/eficode/secure-handling-of-secrets/internal/kubeconfig"
 	"github.com/eficode/secure-handling-of-secrets/internal/logger"
@@ -64,6 +67,7 @@ func rootCmd() *cobra.Command {
 		statusCmd(),
 		clearCacheCmd(),
 		shellInitCmd(),
+		watchCmd(&cfg),
 	)
 	return root
 }
@@ -199,7 +203,7 @@ func shellInitCmd() *cobra.Command {
 func kctxShellSnippet() string {
 	return `
 # kctx shell integration — source this into your shell
-# Usage: source <(kctx shell-init)
+# Usage: eval "$(kctx shell-init)"
 
 kctx() {
   case "$1" in
@@ -214,5 +218,47 @@ kctx() {
       ;;
   esac
 }
+
+# Start the sleep/lock watcher once per shell session.
+if [ -z "${_KCTX_WATCH_PID:-}" ]; then
+  command kctx watch &
+  _KCTX_WATCH_PID=$!
+  trap 'kill "${_KCTX_WATCH_PID:-}" 2>/dev/null' EXIT
+fi
 `
+}
+
+func watchCmd(cfg *config.Config) *cobra.Command {
+	return &cobra.Command{
+		Use:   "watch",
+		Short: "Watch for sleep/lock events and clear cache (run in background by shell-init)",
+		Long: `Run in the background to clear the kubeconfig tmpfile and secret cache
+when the system sleeps or the screen is locked. Normally started automatically
+by shell-init.
+
+On Linux, sleep and screen-lock events are detected via D-Bus (systemd-logind).
+On macOS, sleep is detected via timer drift; screen lock requires a launchd agent.
+On Windows, event hooks are not yet implemented.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			uid := fmt.Sprintf("%d", os.Getuid())
+			slog.Debug("starting kctx watcher", "uid", uid)
+
+			hook := cleanup.New()
+			if err := hook.Register(func() error {
+				slog.Debug("cleanup: clearing kctx cache and managed kubeconfigs")
+				cache := secrets.NewCache()
+				_ = cache.Clear(uid)
+				kubeconfig.ClearManaged()
+				return nil
+			}); err != nil {
+				return fmt.Errorf("registering cleanup hook: %w", err)
+			}
+			defer hook.Unregister()
+
+			sigCh := make(chan os.Signal, 1)
+			signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP)
+			<-sigCh
+			return nil
+		},
+	}
 }

--- a/cmd/kctx/main.go
+++ b/cmd/kctx/main.go
@@ -202,8 +202,8 @@ func shellInitCmd() *cobra.Command {
 
 func kctxShellSnippet() string {
 	return `
-# kctx shell integration — source this into your shell
-# Usage: eval "$(kctx shell-init)"
+# kctx shell integration — add to ~/.bashrc or ~/.zshrc:
+# eval "$(kctx shell-init)"
 
 kctx() {
   case "$1" in

--- a/cmd/kctx/main.go
+++ b/cmd/kctx/main.go
@@ -67,7 +67,7 @@ func rootCmd() *cobra.Command {
 		statusCmd(),
 		clearCacheCmd(),
 		shellInitCmd(),
-		watchCmd(&cfg),
+		watchCmd(),
 	)
 	return root
 }
@@ -219,14 +219,28 @@ kctx() {
   esac
 }
 
-# Unset KUBECONFIG when the watcher signals that sleep/lock occurred.
-_kctx_check_unload() {
+# Derive an idempotent token for the current unload request so each shell can
+# observe the event once without consuming the shared sentinel.
+_kctx_unload_token() {
   local f="/dev/shm/kctx-${UID}-unload-requested"
   [ -f "$f" ] || f="/tmp/kctx-${UID}-unload-requested"
-  [ -f "$f" ] || return 0
-  rm -f "$f" 2>/dev/null
+  [ -f "$f" ] || return 1
+  stat -c '%Y:%i:%s' "$f" 2>/dev/null || stat -f '%m:%i:%z' "$f" 2>/dev/null
+}
+
+# Unset KUBECONFIG when the watcher signals that sleep/lock occurred.
+# Each shell tracks the last token it acted on so only the first prompt after
+# the event triggers unload — subsequent prompts are no-ops until the next event.
+_kctx_check_unload() {
+  local token
+  token="$(_kctx_unload_token)" || return 0
+  [ "${_KCTX_LAST_UNLOAD_TOKEN:-}" = "$token" ] && return 0
+  _KCTX_LAST_UNLOAD_TOKEN="$token"
   eval "$(command kctx unload 2>/dev/null)" 2>/dev/null || true
 }
+# Record the current sentinel state at init time so pre-existing sentinels from
+# a previous session do not trigger an immediate unload in new shells.
+_KCTX_LAST_UNLOAD_TOKEN="$(_kctx_unload_token 2>/dev/null || true)"
 if [ -n "${ZSH_VERSION:-}" ]; then
   autoload -Uz add-zsh-hook 2>/dev/null && add-zsh-hook precmd _kctx_check_unload
 else
@@ -237,12 +251,12 @@ fi
 if [ -z "${_KCTX_WATCH_PID:-}" ]; then
   command kctx watch &
   _KCTX_WATCH_PID=$!
-  trap 'kill "${_KCTX_WATCH_PID:-}" 2>/dev/null' EXIT
+  trap 'kill "${_KCTX_WATCH_PID:-}" 2>/dev/null; command kctx clear-cache 2>/dev/null' EXIT
 fi
 `
 }
 
-func watchCmd(cfg *config.Config) *cobra.Command {
+func watchCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "watch",
 		Short: "Watch for sleep/lock events and manage kubeconfigs (run in background by shell-init)",

--- a/cmd/kctx/main.go
+++ b/cmd/kctx/main.go
@@ -225,6 +225,7 @@ _kctx_unload_token() {
   local f="/dev/shm/kctx-${UID}-unload-requested"
   [ -f "$f" ] || f="/tmp/kctx-${UID}-unload-requested"
   [ -f "$f" ] || return 1
+  # -c is GNU/Linux (coreutils); -f is BSD/macOS (stat(1)).
   stat -c '%Y:%i:%s' "$f" 2>/dev/null || stat -f '%m:%i:%z' "$f" 2>/dev/null
 }
 

--- a/cmd/renv/detach_unix.go
+++ b/cmd/renv/detach_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package main
+
+import (
+	"log/slog"
+	"syscall"
+)
+
+// detachFromTerminal moves the process into a new session so it is no longer
+// a member of the calling shell's process group.  This prevents Ctrl+C
+// (SIGINT sent to the foreground process group) from killing the watcher.
+func detachFromTerminal() {
+	if _, err := syscall.Setsid(); err != nil {
+		// Setsid fails when the process is already a process-group leader,
+		// which can happen if the shell put the background job in its own
+		// group (job-control enabled).  That's fine — the goal is achieved.
+		slog.Debug("watch: setsid skipped", "reason", err)
+	}
+}

--- a/cmd/renv/detach_windows.go
+++ b/cmd/renv/detach_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package main
+
+// detachFromTerminal is a no-op on Windows; session management is handled
+// by the Windows console host and is not required for the watcher.
+func detachFromTerminal() {}

--- a/cmd/renv/main.go
+++ b/cmd/renv/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -245,14 +246,29 @@ const bashInitScript = `renv() {
   esac
 }
 
-# Unload secret variables when the watcher signals that sleep/lock occurred.
-_renv_check_unload() {
+# Return a token that changes whenever the unload sentinel is refreshed.
+# Reading metadata instead of consuming the file lets every open shell
+# observe the same event once without racing to delete it.
+_renv_unload_token() {
   local f="/dev/shm/renv-${UID}-unload-requested"
   [ -f "$f" ] || f="/tmp/renv-${UID}-unload-requested"
-  [ -f "$f" ] || return 0
-  rm -f "$f" 2>/dev/null
+  [ -f "$f" ] || return 1
+  stat -c '%Y:%i:%s' "$f" 2>/dev/null || stat -f '%m:%i:%z' "$f" 2>/dev/null
+}
+
+# Unload secret variables when the watcher signals that sleep/lock occurred.
+# Each shell tracks the last token it acted on so only the first prompt after
+# the event triggers unload — subsequent prompts are no-ops until the next event.
+_renv_check_unload() {
+  local token
+  token="$(_renv_unload_token)" || return 0
+  [ "${_RENV_LAST_UNLOAD_TOKEN:-}" = "$token" ] && return 0
+  _RENV_LAST_UNLOAD_TOKEN="$token"
   eval "$(command renv unload 2>/dev/null)" 2>/dev/null || true
 }
+# Record the current sentinel state at init time so pre-existing sentinels from
+# a previous session do not trigger an immediate unload in new shells.
+_RENV_LAST_UNLOAD_TOKEN="$(_renv_unload_token 2>/dev/null || true)"
 if [ -n "${ZSH_VERSION:-}" ]; then
   autoload -Uz add-zsh-hook 2>/dev/null && add-zsh-hook precmd _renv_check_unload
 else
@@ -277,19 +293,42 @@ const fishInitScript = `function renv
   end
 end
 
-# Unload secret variables when the watcher signals that sleep/lock occurred.
-function _renv_check_unload --on-event fish_prompt
+# Return a token for the current unload sentinel (mtime:inode:size).
+# Reading metadata instead of consuming the file lets every open shell
+# observe the same event once without racing to delete it.
+function _renv_unload_token
   set -l f /dev/shm/renv-(id -u)-unload-requested
   test -f $f; or set f /tmp/renv-(id -u)-unload-requested
-  test -f $f; or return
-  rm -f $f 2>/dev/null
+  test -f $f; or return 1
+  stat -c '%Y:%i:%s' $f 2>/dev/null; or stat -f '%m:%i:%z' $f 2>/dev/null
+end
+
+# Unload secret variables when the watcher signals that sleep/lock occurred.
+# Each shell tracks the last token it acted on so only the first prompt after
+# the event triggers unload — subsequent prompts are no-ops until the next event.
+function _renv_check_unload --on-event fish_prompt
+  set -l token (_renv_unload_token 2>/dev/null); or return
+  test "$_RENV_LAST_UNLOAD_TOKEN" = "$token"; and return
+  set -g _RENV_LAST_UNLOAD_TOKEN $token
   command renv unload | source 2>/dev/null; or true
 end
+# Record the current sentinel state at init time so pre-existing sentinels
+# do not trigger an immediate unload in new shells.
+set -g _RENV_LAST_UNLOAD_TOKEN (_renv_unload_token 2>/dev/null; or echo "")
 
 # Start the sleep/lock watcher once per shell session.
 if not set -q _RENV_WATCH_PID
   command renv watch &
   set -gx _RENV_WATCH_PID $last_pid
+end
+
+# Terminate the watcher and clear sensitive cache/session material on shell exit.
+function _renv_cleanup --on-event fish_exit
+  if set -q _RENV_WATCH_PID
+    kill $_RENV_WATCH_PID 2>/dev/null; or true
+    set -e _RENV_WATCH_PID
+  end
+  command renv clear-cache 2>/dev/null; or true
 end
 `
 
@@ -315,11 +354,12 @@ All other renv subcommands (exec, yaml, status, …) pass through unchanged.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch shell {
 			case "fish":
-				fmt.Print(fishInitScript)
+				_, err := io.WriteString(cmd.OutOrStdout(), fishInitScript)
+				return err
 			default:
-				fmt.Print(bashInitScript)
+				_, err := io.WriteString(cmd.OutOrStdout(), bashInitScript)
+				return err
 			}
-			return nil
 		},
 	}
 	cmd.Flags().StringVar(&shell, "shell", "bash", "Shell type: bash, zsh, fish")
@@ -477,8 +517,9 @@ org.freedesktop.login1.Manager.PrepareForSleep signals.
 
 Wayland screen lockers (swaylock, waylock) must be triggered via
 'loginctl lock-session' for the Lock signal to reach renv. When the locker
-is invoked directly (e.g. 'exec swaylock') logind is not informed and the
-cache is NOT cleared. The recommended swayidle configuration is:
+is invoked directly (e.g. 'exec swaylock') logind is not informed, so renv
+does not receive the Lock signal and open shells are not told to unload
+secret variables. The recommended swayidle configuration is:
 
   exec swayidle -w \
       timeout 300 'loginctl lock-session' \

--- a/cmd/renv/main.go
+++ b/cmd/renv/main.go
@@ -245,6 +245,20 @@ const bashInitScript = `renv() {
   esac
 }
 
+# Unload secret variables when the watcher signals that sleep/lock occurred.
+_renv_check_unload() {
+  local f="/dev/shm/renv-${UID}-unload-requested"
+  [ -f "$f" ] || f="/tmp/renv-${UID}-unload-requested"
+  [ -f "$f" ] || return 0
+  rm -f "$f" 2>/dev/null
+  eval "$(command renv unload 2>/dev/null)" 2>/dev/null || true
+}
+if [ -n "${ZSH_VERSION:-}" ]; then
+  autoload -Uz add-zsh-hook 2>/dev/null && add-zsh-hook precmd _renv_check_unload
+else
+  PROMPT_COMMAND="_renv_check_unload${PROMPT_COMMAND:+; $PROMPT_COMMAND}"
+fi
+
 # Start the sleep/lock watcher once per shell session.
 if [ -z "${_RENV_WATCH_PID:-}" ]; then
   command renv watch &
@@ -261,6 +275,15 @@ const fishInitScript = `function renv
     case '*'
       command renv $argv
   end
+end
+
+# Unload secret variables when the watcher signals that sleep/lock occurred.
+function _renv_check_unload --on-event fish_prompt
+  set -l f /dev/shm/renv-(id -u)-unload-requested
+  test -f $f; or set f /tmp/renv-(id -u)-unload-requested
+  test -f $f; or return
+  rm -f $f 2>/dev/null
+  command renv unload | source 2>/dev/null; or true
 end
 
 # Start the sleep/lock watcher once per shell session.
@@ -458,6 +481,8 @@ Start manually:
 				_ = cache.Clear(uid)
 				_ = secrets.ClearStoredSession(uid)
 				_ = secrets.ClearStoredLocalPassword(uid)
+				// Signal open shells to unload secret variables on their next prompt.
+				_ = secrets.RequestUnload(uid)
 				return nil
 			}); err != nil {
 				return fmt.Errorf("registering cleanup hook: %w", err)

--- a/cmd/renv/main.go
+++ b/cmd/renv/main.go
@@ -5,8 +5,10 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"os/signal"
 	"syscall"
 
+	"github.com/eficode/secure-handling-of-secrets/internal/cleanup"
 	"github.com/eficode/secure-handling-of-secrets/internal/config"
 	"github.com/eficode/secure-handling-of-secrets/internal/env"
 	"github.com/eficode/secure-handling-of-secrets/internal/logger"
@@ -84,6 +86,7 @@ func rootCmd() *cobra.Command {
 		clearCacheCmd(),
 		statusCmd(),
 		unloadCmd(),
+		watchCmd(),
 	)
 	return root
 }
@@ -228,16 +231,26 @@ The resolved variables override any same-named variables already in the environm
 
 // bashInitScript is the shell function emitted by `renv shell-init` for bash/zsh.
 // It wraps `resolve` and `unload` with eval so the user never has to type it.
+// It also starts a background watcher that clears the cache on sleep/lock.
 const bashInitScript = `renv() {
   case "$1" in
     resolve|unload)
-      eval "$(command renv "$@")"
+      # Strip the standalone EXIT trap emitted by resolve — the shell-init
+      # trap below covers cache clear and watcher shutdown together.
+      eval "$(command renv "$@" | grep -v '^trap ')"
       ;;
     *)
       command renv "$@"
       ;;
   esac
 }
+
+# Start the sleep/lock watcher once per shell session.
+if [ -z "${_RENV_WATCH_PID:-}" ]; then
+  command renv watch &
+  _RENV_WATCH_PID=$!
+  trap 'kill "${_RENV_WATCH_PID:-}" 2>/dev/null; command renv clear-cache 2>/dev/null' EXIT
+fi
 `
 
 // fishInitScript is the shell function emitted by `renv shell-init --shell fish`.
@@ -248,6 +261,12 @@ const fishInitScript = `function renv
     case '*'
       command renv $argv
   end
+end
+
+# Start the sleep/lock watcher once per shell session.
+if not set -q _RENV_WATCH_PID
+  command renv watch &
+  set -gx _RENV_WATCH_PID $last_pid
 end
 `
 
@@ -410,6 +429,44 @@ The output must be evaluated by your shell:
 				return err
 			}
 			_ = secrets.ClearVarNames(uid)
+			return nil
+		},
+	}
+}
+
+func watchCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "watch",
+		Short: "Watch for sleep/lock events and clear cache (run in background by shell-init)",
+		Long: `Run in the background to clear the secret cache when the system
+sleeps or the screen is locked. Normally started automatically by shell-init.
+
+On Linux, sleep and screen-lock events are detected via D-Bus (systemd-logind).
+On macOS, sleep is detected via timer drift; screen lock requires a launchd agent.
+On Windows, event hooks are not yet implemented.
+
+Start manually:
+  renv watch &`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			uid := fmt.Sprintf("%d", os.Getuid())
+			slog.Debug("starting renv watcher", "uid", uid)
+
+			hook := cleanup.New()
+			if err := hook.Register(func() error {
+				slog.Debug("cleanup: clearing renv cache and session")
+				cache := secrets.NewCache()
+				_ = cache.Clear(uid)
+				_ = secrets.ClearStoredSession(uid)
+				_ = secrets.ClearStoredLocalPassword(uid)
+				return nil
+			}); err != nil {
+				return fmt.Errorf("registering cleanup hook: %w", err)
+			}
+			defer hook.Unregister()
+
+			sigCh := make(chan os.Signal, 1)
+			signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP)
+			<-sigCh
 			return nil
 		},
 	}

--- a/cmd/renv/main.go
+++ b/cmd/renv/main.go
@@ -460,9 +460,16 @@ The output must be evaluated by your shell:
 func watchCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "watch",
-		Short: "Watch for sleep/lock events and clear cache (run in background by shell-init)",
-		Long: `Run in the background to clear the secret cache when the system
-sleeps or the screen is locked. Normally started automatically by shell-init.
+		Short: "Watch for sleep/lock events and manage secrets (run in background by shell-init)",
+		Long: `Run in the background to manage secrets when the system sleeps or the screen
+is locked. Normally started automatically by shell-init.
+
+On lock: secret environment variables are unloaded from open shells. The
+encrypted cache is kept so secrets can be quickly re-resolved after unlock
+without re-entering passwords.
+
+On sleep: the encrypted cache, stored session, and local passwords are cleared,
+requiring full re-authentication after wake.
 
 On Linux, sleep and screen-lock events are detected via D-Bus (systemd-logind).
 The watcher listens for org.freedesktop.login1.Session.Lock and
@@ -491,18 +498,32 @@ Start manually:
 			slog.Debug("starting renv watcher", "uid", uid)
 
 			hook := cleanup.New()
-			if err := hook.Register(func() error {
-				slog.Debug("cleanup: clearing renv cache and session")
+
+			// On lock: unload secret variables from open shells.
+			// The cache is kept so secrets can be re-resolved after unlock
+			// without re-entering passwords.
+			if err := hook.RegisterLock(func() error {
+				slog.Debug("cleanup: unloading renv variables on lock")
+				_ = secrets.RequestUnload(uid)
+				return nil
+			}); err != nil {
+				return fmt.Errorf("registering lock hook: %w", err)
+			}
+
+			// On sleep: clear the encrypted cache and all stored credentials.
+			// This forces full re-authentication after wake.
+			if err := hook.RegisterSleep(func() error {
+				slog.Debug("cleanup: clearing renv cache and session on sleep")
 				cache := secrets.NewCache()
 				_ = cache.Clear(uid)
 				_ = secrets.ClearStoredSession(uid)
 				_ = secrets.ClearStoredLocalPassword(uid)
-				// Signal open shells to unload secret variables on their next prompt.
 				_ = secrets.RequestUnload(uid)
 				return nil
 			}); err != nil {
-				return fmt.Errorf("registering cleanup hook: %w", err)
+				return fmt.Errorf("registering sleep hook: %w", err)
 			}
+
 			defer hook.Unregister()
 
 			sigCh := make(chan os.Signal, 1)

--- a/cmd/renv/main.go
+++ b/cmd/renv/main.go
@@ -253,6 +253,7 @@ _renv_unload_token() {
   local f="/dev/shm/renv-${UID}-unload-requested"
   [ -f "$f" ] || f="/tmp/renv-${UID}-unload-requested"
   [ -f "$f" ] || return 1
+  # -c is GNU/Linux (coreutils); -f is BSD/macOS (stat(1)).
   stat -c '%Y:%i:%s' "$f" 2>/dev/null || stat -f '%m:%i:%z' "$f" 2>/dev/null
 }
 
@@ -300,6 +301,7 @@ function _renv_unload_token
   set -l f /dev/shm/renv-(id -u)-unload-requested
   test -f $f; or set f /tmp/renv-(id -u)-unload-requested
   test -f $f; or return 1
+  # -c is GNU/Linux (coreutils); -f is BSD/macOS (stat(1)).
   stat -c '%Y:%i:%s' $f 2>/dev/null; or stat -f '%m:%i:%z' $f 2>/dev/null
 end
 

--- a/cmd/renv/main.go
+++ b/cmd/renv/main.go
@@ -465,6 +465,22 @@ func watchCmd() *cobra.Command {
 sleeps or the screen is locked. Normally started automatically by shell-init.
 
 On Linux, sleep and screen-lock events are detected via D-Bus (systemd-logind).
+The watcher listens for org.freedesktop.login1.Session.Lock and
+org.freedesktop.login1.Manager.PrepareForSleep signals.
+
+Wayland screen lockers (swaylock, waylock) must be triggered via
+'loginctl lock-session' for the Lock signal to reach renv. When the locker
+is invoked directly (e.g. 'exec swaylock') logind is not informed and the
+cache is NOT cleared. The recommended swayidle configuration is:
+
+  exec swayidle -w \
+      timeout 300 'loginctl lock-session' \
+      lock 'swaylock -f' \
+      before-sleep 'loginctl lock-session'
+
+  # sway keybind (e.g. in ~/.config/sway/config)
+  bindsym $mod+l exec loginctl lock-session
+
 On macOS, sleep is detected via timer drift; screen lock requires a launchd agent.
 On Windows, event hooks are not yet implemented.
 

--- a/cmd/renv/main.go
+++ b/cmd/renv/main.go
@@ -494,6 +494,7 @@ On Windows, event hooks are not yet implemented.
 Start manually:
   renv watch &`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			detachFromTerminal()
 			uid := fmt.Sprintf("%d", os.Getuid())
 			slog.Debug("starting renv watcher", "uid", uid)
 

--- a/docs/renv.md
+++ b/docs/renv.md
@@ -227,6 +227,46 @@ timeouts:
   vault: 30s       # per vault subprocess call (env: RENV_TIMEOUT_VAULT)
 ```
 
+## Screen locker integration (Linux / Wayland)
+
+`renv watch` clears the secret cache whenever the system sleeps or the screen is
+locked. On Linux it listens for two D-Bus signals from systemd-logind:
+
+| Signal | Trigger |
+|--------|---------|
+| `org.freedesktop.login1.Manager.PrepareForSleep` | System suspend / hibernate |
+| `org.freedesktop.login1.Session.Lock` | Session lock (`loginctl lock-session`) |
+
+### swaylock / waylock
+
+Wayland screen lockers such as **swaylock** and **waylock** do **not** signal
+logind when invoked directly. The `Session.Lock` signal only fires when locking
+goes through `loginctl lock-session`. The recommended setup is to have
+**swayidle** call `loginctl lock-session` and then start the locker via swayidle's
+`lock` event:
+
+```bash
+# ~/.config/sway/config (or your Wayland compositor config)
+exec swayidle -w \
+    timeout 300 'loginctl lock-session' \
+    lock 'swaylock -f' \
+    before-sleep 'loginctl lock-session'
+
+# Lock keybind — must go through loginctl, not exec swaylock directly
+bindsym $mod+l exec loginctl lock-session
+```
+
+With this setup:
+1. `loginctl lock-session` causes logind to emit `Session.Lock`
+2. renv's watcher receives the signal and clears the cache immediately
+3. swayidle's `lock` event fires and starts swaylock/waylock
+
+For **waylock**, use the same pattern — replace `swaylock -f` with `waylock`.
+
+> **Note:** If you use `bindsym $mod+l exec swaylock` (direct invocation),
+> logind is not informed of the lock and the renv cache will **not** be cleared
+> until the next `before-sleep` event or until the shell exits.
+
 ## Environment variables
 
 | Variable | Description |

--- a/docs/renv.md
+++ b/docs/renv.md
@@ -227,45 +227,51 @@ timeouts:
   vault: 30s       # per vault subprocess call (env: RENV_TIMEOUT_VAULT)
 ```
 
-## Screen locker integration (Linux / Wayland)
+## Sleep and screen-lock integration (Linux)
 
-`renv watch` clears the secret cache whenever the system sleeps or the screen is
-locked. On Linux it listens for two D-Bus signals from systemd-logind:
+`renv watch` reacts differently to sleep and lock events:
 
-| Signal | Trigger |
-|--------|---------|
+| Event | Action |
+|-------|--------|
+| Screen locked | Secret env vars unloaded from open shells. Cache kept — secrets re-resolve quickly after unlock without re-entering passwords. |
+| System suspend / hibernate | Encrypted cache, stored session, and local passwords cleared. Full re-authentication required after wake. |
+
+On Linux the watcher listens for two D-Bus signals emitted by **systemd-logind**:
+
+| D-Bus signal | Trigger |
+|--------------|---------|
+| `org.freedesktop.login1.Session.Lock` | Screen locked via `loginctl lock-session` |
 | `org.freedesktop.login1.Manager.PrepareForSleep` | System suspend / hibernate |
-| `org.freedesktop.login1.Session.Lock` | Session lock (`loginctl lock-session`) |
 
-### swaylock / waylock
+### Requirement: lock via loginctl / D-Bus
 
-Wayland screen lockers such as **swaylock** and **waylock** do **not** signal
-logind when invoked directly. The `Session.Lock` signal only fires when locking
-goes through `loginctl lock-session`. The recommended setup is to have
-**swayidle** call `loginctl lock-session` and then start the locker via swayidle's
-`lock` event:
+**The lock signal only reaches renv when the session is locked through
+`loginctl lock-session`** (or anything else that tells logind to emit
+`Session.Lock` on D-Bus). Lock the session with:
 
 ```bash
-# ~/.config/sway/config (or your Wayland compositor config)
+loginctl lock-session
+```
+
+For automatic locking after inactivity, wire your idle daemon to call
+`loginctl lock-session`. For example with **swayidle**:
+
+```bash
 exec swayidle -w \
     timeout 300 'loginctl lock-session' \
-    lock 'swaylock -f' \
     before-sleep 'loginctl lock-session'
+```
 
-# Lock keybind — must go through loginctl, not exec swaylock directly
+And for a manual keybind in your compositor (e.g. sway):
+
+```
 bindsym $mod+l exec loginctl lock-session
 ```
 
-With this setup:
-1. `loginctl lock-session` causes logind to emit `Session.Lock`
-2. renv's watcher receives the signal and clears the cache immediately
-3. swayidle's `lock` event fires and starts swaylock/waylock
-
-For **waylock**, use the same pattern — replace `swaylock -f` with `waylock`.
-
-> **Note:** If you use `bindsym $mod+l exec swaylock` (direct invocation),
-> logind is not informed of the lock and the renv cache will **not** be cleared
-> until the next `before-sleep` event or until the shell exits.
+> **Note:** Invoking a screen locker directly (e.g. `exec swaylock` or
+> `exec waylock`) does **not** inform logind. renv will not receive the lock
+> signal and secret variables will remain in the shell until the system sleeps
+> or the shell exits.
 
 ## Environment variables
 

--- a/docs/renv.md
+++ b/docs/renv.md
@@ -16,10 +16,10 @@ Add this **once** to your shell config — then `renv resolve .env` just works, 
 
 ```bash
 # ~/.bashrc or ~/.zshrc
-eval "$(renv init)"
+eval "$(renv shell-init)"
 
 # fish: ~/.config/fish/config.fish
-renv init --shell fish | source
+renv shell-init --shell fish | source
 ```
 
 After that, simply:
@@ -42,7 +42,7 @@ scripts, CI pipelines, and one-off commands.
 
 ### Manual eval (original behaviour)
 
-If you prefer not to use `renv init`, you can always eval explicitly:
+If you prefer not to use `renv shell-init`, you can always eval explicitly:
 
 ```bash
 eval "$(renv resolve .env)"
@@ -129,7 +129,7 @@ API_KEY=vault://secret/myapp#api_key
 
 | Command | Description |
 |---------|-------------|
-| `renv init [--shell bash\|zsh\|fish]` | Print shell function so resolve/unload work without eval |
+| `renv shell-init [--shell bash\|zsh\|fish]` | Print shell function so resolve/unload work without eval |
 | `renv resolve [file]` | Resolve and emit exports (default file: `.env`) |
 | `renv exec [--env file] -- cmd [args]` | Run command with resolved vars injected (no eval) |
 | `renv unload` | Emit unset commands for all tracked variables |

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -3,9 +3,14 @@ package cleanup
 // CleanupFunc is a function to call during cleanup events.
 type CleanupFunc func() error
 
-// Hook registers cleanup functions to be called on sleep, lock, and shutdown.
+// Hook registers cleanup functions to be called on specific system events.
+// Use RegisterLock for functions that should run when the screen is locked,
+// and RegisterSleep for functions that should run when the system suspends.
 type Hook interface {
-	Register(fns ...CleanupFunc) error
+	// RegisterLock registers functions to call when the screen is locked.
+	RegisterLock(fns ...CleanupFunc) error
+	// RegisterSleep registers functions to call when the system suspends/sleeps.
+	RegisterSleep(fns ...CleanupFunc) error
 	Unregister()
 }
 

--- a/internal/cleanup/cleanup_darwin.go
+++ b/internal/cleanup/cleanup_darwin.go
@@ -4,6 +4,7 @@ package cleanup
 
 import (
 	"log/slog"
+	"sync"
 	"time"
 )
 
@@ -14,8 +15,10 @@ import (
 //
 // Screen lock events are not detectable in pure Go without CGo/IOKit.
 type darwinHook struct {
-	fns  []CleanupFunc
-	done chan struct{}
+	mu       sync.Mutex
+	sleepFns []CleanupFunc
+	done     chan struct{}
+	started  bool
 }
 
 const pollInterval = 10 * time.Second
@@ -24,10 +27,25 @@ func newHook() Hook {
 	return &darwinHook{done: make(chan struct{})}
 }
 
-func (h *darwinHook) Register(fns ...CleanupFunc) error {
-	h.fns = append(h.fns, fns...)
-	slog.Debug("cleanup: darwin sleep watcher started (timer drift)")
-	go h.poll()
+// RegisterLock is a no-op on macOS: screen lock detection requires CGo/IOKit.
+func (h *darwinHook) RegisterLock(fns ...CleanupFunc) error {
+	slog.Debug("cleanup: screen lock detection not available on macOS without CGo; lock hooks ignored")
+	return nil
+}
+
+func (h *darwinHook) RegisterSleep(fns ...CleanupFunc) error {
+	h.mu.Lock()
+	h.sleepFns = append(h.sleepFns, fns...)
+	alreadyStarted := h.started
+	if !alreadyStarted {
+		h.started = true
+	}
+	h.mu.Unlock()
+
+	if !alreadyStarted {
+		slog.Debug("cleanup: darwin sleep watcher started (timer drift)")
+		go h.poll()
+	}
 	return nil
 }
 
@@ -44,17 +62,20 @@ func (h *darwinHook) poll() {
 			// the system slept and just woke up.
 			if t.Sub(last) > 2*pollInterval {
 				slog.Debug("cleanup: sleep/wake detected via timer drift, running hooks")
-				h.runAll()
+				h.runSleep()
 			}
 			last = t
 		}
 	}
 }
 
-func (h *darwinHook) runAll() {
-	for _, fn := range h.fns {
+func (h *darwinHook) runSleep() {
+	h.mu.Lock()
+	fns := append([]CleanupFunc(nil), h.sleepFns...)
+	h.mu.Unlock()
+	for _, fn := range fns {
 		if err := fn(); err != nil {
-			slog.Warn("cleanup: hook error", "error", err)
+			slog.Warn("cleanup: sleep hook error", "error", err)
 		}
 	}
 }

--- a/internal/cleanup/cleanup_darwin.go
+++ b/internal/cleanup/cleanup_darwin.go
@@ -2,22 +2,71 @@
 
 package cleanup
 
-import "log"
+import (
+	"log/slog"
+	"time"
+)
 
-// TODO: Implement using IOKit/NSWorkspace for sleep and lock events.
-
+// darwinHook detects sleep/wake transitions using timer drift.
+// When the system sleeps the goroutine is suspended; on wake the next tick
+// fires with a gap larger than 2× the poll interval, indicating a sleep/wake
+// cycle occurred.
+//
+// Screen lock events are not detectable in pure Go without CGo/IOKit.
 type darwinHook struct {
-	fns []CleanupFunc
+	fns  []CleanupFunc
+	done chan struct{}
 }
 
+const pollInterval = 10 * time.Second
+
 func newHook() Hook {
-	return &darwinHook{}
+	return &darwinHook{done: make(chan struct{})}
 }
 
 func (h *darwinHook) Register(fns ...CleanupFunc) error {
-	log.Println("cleanup: hooks not yet implemented on Darwin; secrets will not be cleared on sleep/lock")
 	h.fns = append(h.fns, fns...)
+	slog.Debug("cleanup: darwin sleep watcher started (timer drift)")
+	go h.poll()
 	return nil
 }
 
-func (h *darwinHook) Unregister() {}
+func (h *darwinHook) poll() {
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	last := time.Now()
+	for {
+		select {
+		case <-h.done:
+			return
+		case t := <-ticker.C:
+			// If more than 2× the interval has elapsed the goroutine was suspended —
+			// the system slept and just woke up.
+			if t.Sub(last) > 2*pollInterval {
+				slog.Debug("cleanup: sleep/wake detected via timer drift, running hooks")
+				h.runAll()
+			}
+			last = t
+		}
+	}
+}
+
+func (h *darwinHook) runAll() {
+	for _, fn := range h.fns {
+		if err := fn(); err != nil {
+			slog.Warn("cleanup: hook error", "error", err)
+		}
+	}
+}
+
+func (h *darwinHook) Unregister() {
+	if h.done != nil {
+		select {
+		case <-h.done:
+		default:
+			close(h.done)
+		}
+	}
+}
+
+var _ Hook = (*darwinHook)(nil)

--- a/internal/cleanup/cleanup_linux.go
+++ b/internal/cleanup/cleanup_linux.go
@@ -3,6 +3,8 @@
 package cleanup
 
 import (
+	"os"
+
 	"log/slog"
 
 	"github.com/godbus/dbus/v5"
@@ -36,16 +38,35 @@ func (h *linuxHook) Register(fns ...CleanupFunc) error {
 		slog.Warn("cleanup: cannot subscribe to PrepareForSleep", "error", err)
 	}
 
-	// Subscribe to Lock signal
-	if err := conn.AddMatchSignal(
+	// Resolve the current session object path so we subscribe to Lock signals
+	// for exactly this session. Without the path, logind does not route the
+	// per-session signal to us.
+	sessionPath := h.currentSessionPath(conn)
+	lockOpts := []dbus.MatchOption{
 		dbus.WithMatchInterface("org.freedesktop.login1.Session"),
 		dbus.WithMatchMember("Lock"),
-	); err != nil {
+	}
+	if sessionPath != "" {
+		lockOpts = append(lockOpts, dbus.WithMatchObjectPath(sessionPath))
+	}
+	if err := conn.AddMatchSignal(lockOpts...); err != nil {
 		slog.Warn("cleanup: cannot subscribe to Lock", "error", err)
 	}
 
 	go h.listen()
 	return nil
+}
+
+// currentSessionPath returns the D-Bus object path of the current login session.
+func (h *linuxHook) currentSessionPath(conn *dbus.Conn) dbus.ObjectPath {
+	obj := conn.Object("org.freedesktop.login1", "/org/freedesktop/login1")
+	var path dbus.ObjectPath
+	if err := obj.Call("org.freedesktop.login1.Manager.GetSessionByPID", 0, uint32(os.Getpid())).Store(&path); err != nil {
+		slog.Debug("cleanup: cannot resolve session path, Lock match will be broad", "error", err)
+		return ""
+	}
+	slog.Debug("cleanup: resolved session path for Lock subscription", "path", path)
+	return path
 }
 
 func (h *linuxHook) listen() {

--- a/internal/cleanup/cleanup_linux.go
+++ b/internal/cleanup/cleanup_linux.go
@@ -3,7 +3,7 @@
 package cleanup
 
 import (
-	"log"
+	"log/slog"
 
 	"github.com/godbus/dbus/v5"
 )
@@ -23,7 +23,7 @@ func (h *linuxHook) Register(fns ...CleanupFunc) error {
 	conn, err := dbus.ConnectSystemBus()
 	if err != nil {
 		// Non-fatal: log and continue without hooks
-		log.Printf("cleanup: cannot connect to D-Bus system bus: %v", err)
+		slog.Warn("cleanup: cannot connect to D-Bus system bus", "error", err)
 		return nil
 	}
 	h.conn = conn
@@ -33,7 +33,7 @@ func (h *linuxHook) Register(fns ...CleanupFunc) error {
 		dbus.WithMatchInterface("org.freedesktop.login1.Manager"),
 		dbus.WithMatchMember("PrepareForSleep"),
 	); err != nil {
-		log.Printf("cleanup: cannot subscribe to PrepareForSleep: %v", err)
+		slog.Warn("cleanup: cannot subscribe to PrepareForSleep", "error", err)
 	}
 
 	// Subscribe to Lock signal
@@ -41,7 +41,7 @@ func (h *linuxHook) Register(fns ...CleanupFunc) error {
 		dbus.WithMatchInterface("org.freedesktop.login1.Session"),
 		dbus.WithMatchMember("Lock"),
 	); err != nil {
-		log.Printf("cleanup: cannot subscribe to Lock: %v", err)
+		slog.Warn("cleanup: cannot subscribe to Lock", "error", err)
 	}
 
 	go h.listen()
@@ -76,7 +76,7 @@ func (h *linuxHook) listen() {
 func (h *linuxHook) runAll() {
 	for _, fn := range h.fns {
 		if err := fn(); err != nil {
-			log.Printf("cleanup: hook error: %v", err)
+			slog.Warn("cleanup: hook error", "error", err)
 		}
 	}
 }

--- a/internal/cleanup/cleanup_linux.go
+++ b/internal/cleanup/cleanup_linux.go
@@ -39,17 +39,20 @@ func (h *linuxHook) RegisterSleep(fns ...CleanupFunc) error {
 }
 
 // ensureStarted connects to D-Bus and starts the listener goroutine once.
+// started is only set to true after a successful connection so that transient
+// failures (e.g. D-Bus not yet available at boot) allow a retry on the next
+// RegisterLock/RegisterSleep call.
 func (h *linuxHook) ensureStarted() error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.started {
 		return nil
 	}
-	h.started = true
 
 	conn, err := dbus.ConnectSystemBus()
 	if err != nil {
-		// Non-fatal: log and continue without hooks
+		// Non-fatal: log and continue without hooks; leave started=false so
+		// the next registration call can retry the connection.
 		slog.Warn("cleanup: cannot connect to D-Bus system bus", "error", err)
 		return nil
 	}
@@ -79,6 +82,7 @@ func (h *linuxHook) ensureStarted() error {
 	}
 
 	go h.listen()
+	h.started = true
 	return nil
 }
 

--- a/internal/cleanup/cleanup_linux.go
+++ b/internal/cleanup/cleanup_linux.go
@@ -4,6 +4,7 @@ package cleanup
 
 import (
 	"os"
+	"sync"
 
 	"log/slog"
 
@@ -11,17 +12,41 @@ import (
 )
 
 type linuxHook struct {
-	conn *dbus.Conn
-	fns  []CleanupFunc
-	done chan struct{}
+	mu       sync.Mutex
+	conn     *dbus.Conn
+	lockFns  []CleanupFunc
+	sleepFns []CleanupFunc
+	done     chan struct{}
+	started  bool
 }
 
 func newHook() Hook {
 	return &linuxHook{done: make(chan struct{})}
 }
 
-func (h *linuxHook) Register(fns ...CleanupFunc) error {
-	h.fns = append(h.fns, fns...)
+func (h *linuxHook) RegisterLock(fns ...CleanupFunc) error {
+	h.mu.Lock()
+	h.lockFns = append(h.lockFns, fns...)
+	h.mu.Unlock()
+	return h.ensureStarted()
+}
+
+func (h *linuxHook) RegisterSleep(fns ...CleanupFunc) error {
+	h.mu.Lock()
+	h.sleepFns = append(h.sleepFns, fns...)
+	h.mu.Unlock()
+	return h.ensureStarted()
+}
+
+// ensureStarted connects to D-Bus and starts the listener goroutine once.
+func (h *linuxHook) ensureStarted() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.started {
+		return nil
+	}
+	h.started = true
+
 	conn, err := dbus.ConnectSystemBus()
 	if err != nil {
 		// Non-fatal: log and continue without hooks
@@ -82,11 +107,11 @@ func (h *linuxHook) listen() {
 			if sig.Name == "org.freedesktop.login1.Manager.PrepareForSleep" {
 				if len(sig.Body) > 0 {
 					if going, ok := sig.Body[0].(bool); ok && going {
-						h.runAll()
+						h.runSleep()
 					}
 				}
 			} else if sig.Name == "org.freedesktop.login1.Session.Lock" {
-				h.runAll()
+				h.runLock()
 			}
 		case <-h.done:
 			return
@@ -94,10 +119,24 @@ func (h *linuxHook) listen() {
 	}
 }
 
-func (h *linuxHook) runAll() {
-	for _, fn := range h.fns {
+func (h *linuxHook) runLock() {
+	h.mu.Lock()
+	fns := append([]CleanupFunc(nil), h.lockFns...)
+	h.mu.Unlock()
+	for _, fn := range fns {
 		if err := fn(); err != nil {
-			slog.Warn("cleanup: hook error", "error", err)
+			slog.Warn("cleanup: lock hook error", "error", err)
+		}
+	}
+}
+
+func (h *linuxHook) runSleep() {
+	h.mu.Lock()
+	fns := append([]CleanupFunc(nil), h.sleepFns...)
+	h.mu.Unlock()
+	for _, fn := range fns {
+		if err := fn(); err != nil {
+			slog.Warn("cleanup: sleep hook error", "error", err)
 		}
 	}
 }

--- a/internal/cleanup/cleanup_windows.go
+++ b/internal/cleanup/cleanup_windows.go
@@ -2,7 +2,7 @@
 
 package cleanup
 
-import "log"
+import "log/slog"
 
 // TODO: Implement using WTS session change events / Windows power events.
 
@@ -15,7 +15,7 @@ func newHook() Hook {
 }
 
 func (h *windowsHook) Register(fns ...CleanupFunc) error {
-	log.Println("cleanup: hooks not yet implemented on Windows; secrets will not be cleared on sleep/lock")
+	slog.Warn("cleanup: hooks not yet implemented on Windows; secrets will not be cleared on sleep/lock")
 	h.fns = append(h.fns, fns...)
 	return nil
 }

--- a/internal/cleanup/cleanup_windows.go
+++ b/internal/cleanup/cleanup_windows.go
@@ -6,17 +6,19 @@ import "log/slog"
 
 // TODO: Implement using WTS session change events / Windows power events.
 
-type windowsHook struct {
-	fns []CleanupFunc
-}
+type windowsHook struct{}
 
 func newHook() Hook {
 	return &windowsHook{}
 }
 
-func (h *windowsHook) Register(fns ...CleanupFunc) error {
-	slog.Warn("cleanup: hooks not yet implemented on Windows; secrets will not be cleared on sleep/lock")
-	h.fns = append(h.fns, fns...)
+func (h *windowsHook) RegisterLock(fns ...CleanupFunc) error {
+	slog.Warn("cleanup: hooks not yet implemented on Windows; secrets will not be cleared on lock")
+	return nil
+}
+
+func (h *windowsHook) RegisterSleep(fns ...CleanupFunc) error {
+	slog.Warn("cleanup: hooks not yet implemented on Windows; secrets will not be cleared on sleep")
 	return nil
 }
 

--- a/internal/kubeconfig/tmpfile.go
+++ b/internal/kubeconfig/tmpfile.go
@@ -33,3 +33,18 @@ func NewTempFile(prefix string) (*os.File, error) {
 	slog.Debug("created temp file", "path", f.Name())
 	return f, nil
 }
+
+// ClearManaged removes all kctx-managed kubeconfig tmpfiles from /dev/shm and /tmp.
+// Only files with the "kctx-" prefix are removed.
+func ClearManaged() {
+	for _, dir := range []string{"/dev/shm", "/tmp"} {
+		matches, err := filepath.Glob(filepath.Join(dir, "kctx-*.tmp"))
+		if err != nil {
+			continue
+		}
+		for _, path := range matches {
+			slog.Debug("cleanup: removing managed kubeconfig", "path", path)
+			os.Remove(path)
+		}
+	}
+}

--- a/internal/kubeconfig/tmpfile.go
+++ b/internal/kubeconfig/tmpfile.go
@@ -48,3 +48,22 @@ func ClearManaged() {
 		}
 	}
 }
+
+// UnloadRequestFile returns the path of the sentinel file used to signal
+// shells to run kctx unload on their next prompt draw.
+func UnloadRequestFile(uid string) string {
+	dir := "/tmp"
+	if fi, err := os.Stat("/dev/shm"); err == nil && fi.IsDir() {
+		dir = "/dev/shm"
+	}
+	return filepath.Join(dir, "kctx-"+uid+"-unload-requested")
+}
+
+// RequestUnload creates the sentinel file. Shell PROMPT_COMMAND/precmd hooks
+// installed by kctx shell-init check for this file and call kctx unload when
+// they find it, unsetting KUBECONFIG from the shell on the next prompt.
+func RequestUnload(uid string) error {
+	path := UnloadRequestFile(uid)
+	slog.Debug("requesting kctx shell unload via sentinel", "path", path)
+	return os.WriteFile(path, []byte{}, 0600)
+}

--- a/internal/kubeconfig/tmpfile.go
+++ b/internal/kubeconfig/tmpfile.go
@@ -65,5 +65,10 @@ func UnloadRequestFile(uid string) string {
 func RequestUnload(uid string) error {
 	path := UnloadRequestFile(uid)
 	slog.Debug("requesting kctx shell unload via sentinel", "path", path)
+	// Guard against symlink attacks: if the target path is already a symlink,
+	// refuse to write rather than following the link to an unintended file.
+	if fi, err := os.Lstat(path); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to write unload sentinel %q: path is a symlink", path)
+	}
 	return os.WriteFile(path, []byte{}, 0600)
 }

--- a/internal/kubeconfig/tmpfile_test.go
+++ b/internal/kubeconfig/tmpfile_test.go
@@ -11,7 +11,7 @@ func TestUnloadRequestFile(t *testing.T) {
 	if path == "" {
 		t.Fatal("UnloadRequestFile returned empty string")
 	}
-	if path[:8] != "/dev/shm" && path[:4] != "/tmp" {
+	if len(path) < 8 || (path[:8] != "/dev/shm" && path[:4] != "/tmp") {
 		t.Errorf("unexpected base dir in path %q", path)
 	}
 }
@@ -63,10 +63,7 @@ func TestRequestUnload_RejectsSymlink(t *testing.T) {
 
 func TestClearManaged(t *testing.T) {
 	// Create a few fake kctx-*.tmp files in /tmp.
-	dir := t.TempDir()
-
-	// We'll patch /tmp via the glob pattern by creating files with the right naming.
-	// Since ClearManaged searches /dev/shm and /tmp specifically, we create real files.
+	// ClearManaged searches /dev/shm and /tmp specifically.
 	paths := []string{
 		filepath.Join("/tmp", "kctx-test-clear-managed-1.tmp"),
 		filepath.Join("/tmp", "kctx-test-clear-managed-2.tmp"),
@@ -82,7 +79,6 @@ func TestClearManaged(t *testing.T) {
 			os.Remove(p)
 		}
 	})
-	_ = dir // used for t.TempDir() but actual files are in /tmp
 
 	// Verify the files exist before clearing.
 	for _, p := range paths {

--- a/internal/kubeconfig/tmpfile_test.go
+++ b/internal/kubeconfig/tmpfile_test.go
@@ -1,0 +1,118 @@
+package kubeconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUnloadRequestFile(t *testing.T) {
+	path := UnloadRequestFile("9999")
+	if path == "" {
+		t.Fatal("UnloadRequestFile returned empty string")
+	}
+	if path[:8] != "/dev/shm" && path[:4] != "/tmp" {
+		t.Errorf("unexpected base dir in path %q", path)
+	}
+}
+
+func TestRequestUnload(t *testing.T) {
+	uid := "test-kctx-unload-request"
+	path := UnloadRequestFile(uid)
+	t.Cleanup(func() { os.Remove(path) })
+
+	if err := RequestUnload(uid); err != nil {
+		t.Fatalf("RequestUnload: %v", err)
+	}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("sentinel file not created: %v", err)
+	}
+	if fi.Mode().Perm() != 0600 {
+		t.Errorf("expected mode 0600, got %v", fi.Mode().Perm())
+	}
+}
+
+func TestRequestUnload_RejectsSymlink(t *testing.T) {
+	uid := "test-kctx-unload-symlink"
+	path := UnloadRequestFile(uid)
+
+	// Create a symlink at the sentinel path pointing to a temp file.
+	target := path + "-target"
+	if err := os.WriteFile(target, []byte("original"), 0600); err != nil {
+		t.Fatalf("creating symlink target: %v", err)
+	}
+	t.Cleanup(func() { os.Remove(target); os.Remove(path) })
+
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatalf("creating symlink: %v", err)
+	}
+
+	err := RequestUnload(uid)
+	if err == nil {
+		t.Fatal("expected error when path is a symlink, got nil")
+	}
+
+	// The symlink target should be unchanged — we must not have written through it.
+	data, _ := os.ReadFile(target)
+	if string(data) != "original" {
+		t.Errorf("symlink target was modified (symlink followed): got %q", data)
+	}
+}
+
+func TestClearManaged(t *testing.T) {
+	// Create a few fake kctx-*.tmp files in /tmp.
+	dir := t.TempDir()
+
+	// We'll patch /tmp via the glob pattern by creating files with the right naming.
+	// Since ClearManaged searches /dev/shm and /tmp specifically, we create real files.
+	paths := []string{
+		filepath.Join("/tmp", "kctx-test-clear-managed-1.tmp"),
+		filepath.Join("/tmp", "kctx-test-clear-managed-2.tmp"),
+	}
+	for _, p := range paths {
+		if err := os.WriteFile(p, []byte("test"), 0600); err != nil {
+			t.Fatalf("creating test file %s: %v", p, err)
+		}
+	}
+	// Ensure cleanup even if ClearManaged doesn't get them.
+	t.Cleanup(func() {
+		for _, p := range paths {
+			os.Remove(p)
+		}
+	})
+	_ = dir // used for t.TempDir() but actual files are in /tmp
+
+	// Verify the files exist before clearing.
+	for _, p := range paths {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("expected file %s to exist before ClearManaged", p)
+		}
+	}
+
+	ClearManaged()
+
+	// Verify the files are removed after clearing.
+	for _, p := range paths {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("expected file %s to be removed by ClearManaged", p)
+		}
+	}
+}
+
+func TestClearManaged_NonKctxFilesUntouched(t *testing.T) {
+	// Create a non-kctx file that should NOT be removed.
+	notKctx := filepath.Join("/tmp", "renv-test-not-kctx.tmp")
+	if err := os.WriteFile(notKctx, []byte("keep"), 0600); err != nil {
+		t.Fatalf("creating file: %v", err)
+	}
+	t.Cleanup(func() { os.Remove(notKctx) })
+
+	ClearManaged()
+
+	// The non-kctx file should still exist.
+	if _, err := os.Stat(notKctx); err != nil {
+		t.Errorf("non-kctx file was incorrectly removed by ClearManaged")
+	}
+}

--- a/internal/secrets/vars.go
+++ b/internal/secrets/vars.go
@@ -61,3 +61,22 @@ func ClearVarNames(uid string) error {
 	}
 	return nil
 }
+
+// UnloadRequestFile returns the path of the sentinel file used to signal
+// shells to run renv unload on their next prompt draw.
+func UnloadRequestFile(uid string) string {
+	dir := "/tmp"
+	if fi, err := os.Stat("/dev/shm"); err == nil && fi.IsDir() {
+		dir = "/dev/shm"
+	}
+	return filepath.Join(dir, "renv-"+uid+"-unload-requested")
+}
+
+// RequestUnload creates the sentinel file. Shell PROMPT_COMMAND/precmd hooks
+// installed by renv shell-init check for this file and call renv unload when
+// they find it, clearing secret variables from the shell on the next prompt.
+func RequestUnload(uid string) error {
+	path := UnloadRequestFile(uid)
+	slog.Debug("requesting shell unload via sentinel", "path", path)
+	return os.WriteFile(path, []byte{}, 0600)
+}

--- a/internal/secrets/vars.go
+++ b/internal/secrets/vars.go
@@ -78,5 +78,10 @@ func UnloadRequestFile(uid string) string {
 func RequestUnload(uid string) error {
 	path := UnloadRequestFile(uid)
 	slog.Debug("requesting shell unload via sentinel", "path", path)
+	// Guard against symlink attacks: if the target path is already a symlink,
+	// refuse to write rather than following the link to an unintended file.
+	if fi, err := os.Lstat(path); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to write unload sentinel %q: path is a symlink", path)
+	}
 	return os.WriteFile(path, []byte{}, 0600)
 }

--- a/internal/secrets/vars_test.go
+++ b/internal/secrets/vars_test.go
@@ -92,3 +92,63 @@ func TestVarsFilePath(t *testing.T) {
 		t.Errorf("path %q does not contain uid %q", path, uid)
 	}
 }
+
+func TestUnloadRequestFile(t *testing.T) {
+	path := UnloadRequestFile("9999")
+	if path == "" {
+		t.Fatal("UnloadRequestFile returned empty string")
+	}
+	// Should reside in /dev/shm or /tmp.
+	if path[:8] != "/dev/shm" && path[:4] != "/tmp" {
+		t.Errorf("unexpected base dir in path %q", path)
+	}
+	// Should contain the uid.
+	if len(path) < 4 || (path[:8] != "/dev/shm" && path[:4] != "/tmp") {
+		t.Errorf("path %q does not start with expected dir", path)
+	}
+}
+
+func TestRequestUnload(t *testing.T) {
+	uid := "test-unload-request"
+	path := UnloadRequestFile(uid)
+	t.Cleanup(func() { os.Remove(path) })
+
+	if err := RequestUnload(uid); err != nil {
+		t.Fatalf("RequestUnload: %v", err)
+	}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("sentinel file not created: %v", err)
+	}
+	if fi.Mode().Perm() != 0600 {
+		t.Errorf("expected mode 0600, got %v", fi.Mode().Perm())
+	}
+}
+
+func TestRequestUnload_RejectsSymlink(t *testing.T) {
+	uid := "test-unload-symlink"
+	path := UnloadRequestFile(uid)
+
+	// Create a symlink at the sentinel path pointing to a temp file.
+	target := path + "-target"
+	if err := os.WriteFile(target, []byte("original"), 0600); err != nil {
+		t.Fatalf("creating symlink target: %v", err)
+	}
+	t.Cleanup(func() { os.Remove(target); os.Remove(path) })
+
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatalf("creating symlink: %v", err)
+	}
+
+	err := RequestUnload(uid)
+	if err == nil {
+		t.Fatal("expected error when path is a symlink, got nil")
+	}
+
+	// The symlink target should be unchanged — we must not have written through it.
+	data, _ := os.ReadFile(target)
+	if string(data) != "original" {
+		t.Errorf("symlink target was modified (symlink followed): got %q", data)
+	}
+}

--- a/internal/secrets/vars_test.go
+++ b/internal/secrets/vars_test.go
@@ -3,6 +3,7 @@ package secrets
 import (
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -99,12 +100,13 @@ func TestUnloadRequestFile(t *testing.T) {
 		t.Fatal("UnloadRequestFile returned empty string")
 	}
 	// Should reside in /dev/shm or /tmp.
-	if path[:8] != "/dev/shm" && path[:4] != "/tmp" {
+	if len(path) < 8 || (path[:8] != "/dev/shm" && path[:4] != "/tmp") {
 		t.Errorf("unexpected base dir in path %q", path)
 	}
 	// Should contain the uid.
-	if len(path) < 4 || (path[:8] != "/dev/shm" && path[:4] != "/tmp") {
-		t.Errorf("path %q does not start with expected dir", path)
+	const uid = "9999"
+	if !strings.Contains(path, uid) {
+		t.Errorf("path %q does not contain uid %q", path, uid)
 	}
 }
 


### PR DESCRIPTION
Closes #1

## What this does

Adds `renv watch` and `kctx watch` subcommands — background processes that clear sensitive data when the system sleeps or the screen is locked. `shell-init` is updated to start the watcher automatically.

## Platform support

| Platform | Sleep | Lock |
|----------|-------|------|
| Linux | ✅ D-Bus `PrepareForSleep` (systemd-logind) | ✅ `Session.Lock` signal |
| macOS | ✅ Timer drift (pure Go, no CGo) | ❌ Requires IOKit/CGo |
| Windows | ❌ Stub with warning | ❌ Stub with warning |

**macOS**: the watcher goroutine is suspended when the system sleeps; on wake, the gap between ticks exceeds 2× the poll interval, triggering cleanup. No CGo required.

## Data cleared on sleep/lock

- **renv**: encrypted secret cache, stored BW session, stored local password
- **kctx**: encrypted secret cache, all kctx-managed kubeconfig tmpfiles (`kubeconfig.ClearManaged()`)

## Shell integration changes

`shell-init` (bash/zsh/fish) now:
1. Starts `renv watch &` / `kctx watch &` in the background
2. Stores the watcher PID in `$_RENV_WATCH_PID` / `$_KCTX_WATCH_PID` (idempotent — won't start a second watcher if sourced again)
3. Kills the watcher and clears the cache on shell EXIT

The bash/zsh `renv()` shell function now strips the standalone `trap` line from `renv resolve` output to avoid overriding the shell-init trap.

### Idempotent unload signaling

Shell prompt hooks (`PROMPT_COMMAND` / `precmd` / `fish_prompt`) no longer delete the sentinel file. Instead, each shell derives a `mtime:inode:size` token via `stat` and tracks the last-seen token in `_RENV_LAST_UNLOAD_TOKEN` / `_KCTX_LAST_UNLOAD_TOKEN`. This means all open shells independently observe and react to the same sleep/lock event — the first shell to hit a prompt no longer consumes the signal for everyone else. New shells record the current sentinel state at init time so stale events from previous sessions are ignored.

### Fish shell exit hook

Fish shells now register a `function _renv_cleanup --on-event fish_exit` handler that kills the watcher process and runs `renv clear-cache`, matching the bash/zsh `trap ... EXIT` behavior.

## Security improvements

`RequestUnload` in both `internal/secrets` and `internal/kubeconfig` now uses `os.Lstat` to detect and reject symlinks before writing the sentinel file, preventing a local attacker from pre-creating a symlink to cause the watcher to truncate an arbitrary user-owned file.

## Reliability improvements

`ensureStarted` in `internal/cleanup/cleanup_linux.go` now only sets `h.started = true` after a successful D-Bus connection. Transient failures (e.g. D-Bus not yet available at boot) no longer permanently disable hooks for the lifetime of the process — the next `RegisterLock`/`RegisterSleep` call will retry the connection.

## Testing checklist

- [x] Linux: sleep clears cache (`renv status` empty after wake)
- [x] Linux: screen lock clears cache
- [ ] macOS: sleep clears cache
- [x] Watcher PID is killed on shell exit
- [x] `renv watch` exits cleanly on SIGTERM / SIGINT / SIGHUP
- [x] Sourcing shell-init twice does not start a second watcher
- [x] Multiple open shells all unload on sleep/lock (token-based signaling)
- [x] `RequestUnload` rejects symlink paths