### PR TITLE
Feat/dev versioning

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,6 +11,11 @@ builds:
     binary: renv
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X github.com/eficode/secure-handling-of-secrets/internal/version.Version={{.Version}}
+      - -X github.com/eficode/secure-handling-of-secrets/internal/version.Commit={{.ShortCommit}}
+      - -X github.com/eficode/secure-handling-of-secrets/internal/version.BuildDate={{.Date}}
     goos:
       - linux
       - darwin
@@ -27,6 +32,11 @@ builds:
     binary: kctx
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X github.com/eficode/secure-handling-of-secrets/internal/version.Version={{.Version}}
+      - -X github.com/eficode/secure-handling-of-secrets/internal/version.Commit={{.ShortCommit}}
+      - -X github.com/eficode/secure-handling-of-secrets/internal/version.BuildDate={{.Date}}
     goos:
       - linux
       - darwin

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ VERSION       := $(shell \
 	tag=$$(git describe --tags --exact-match 2>/dev/null); \
 	dirty=$$(git status --porcelain 2>/dev/null); \
 	if [ -n "$$tag" ] && [ -z "$$dirty" ]; then \
-		echo "$$tag"; \
+		echo "$${tag#v}"; \
 	elif [ -n "$$dirty" ]; then \
 		echo "$(_BASE_VERSION)-dev+$(COMMIT)-dirty"; \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,18 @@ KCTX    := $(BINDIR)/kctx
 GOFLAGS := -trimpath
 export CGO_ENABLED=0
 
-VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || cat VERSION)
-COMMIT  := $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
+_BASE_VERSION := $(shell cat VERSION)
+COMMIT        := $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
+VERSION       := $(shell \
+	tag=$$(git describe --tags --exact-match 2>/dev/null); \
+	dirty=$$(git status --porcelain 2>/dev/null); \
+	if [ -n "$$tag" ] && [ -z "$$dirty" ]; then \
+		echo "$$tag"; \
+	elif [ -n "$$dirty" ]; then \
+		echo "$(_BASE_VERSION)-dev+$(COMMIT)-dirty"; \
+	else \
+		echo "$(_BASE_VERSION)-dev+$(COMMIT)"; \
+	fi)
 DATE    := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 PKG     := github.com/eficode/secure-handling-of-secrets/internal/version
 LDFLAGS := -s -w \

--- a/cmd/kctx/main.go
+++ b/cmd/kctx/main.go
@@ -27,8 +27,9 @@ func rootCmd() *cobra.Command {
 	var cfg config.Config
 
 	root := &cobra.Command{
-		Use:   "kctx",
-		Short: "Ephemeral kubeconfig switcher via Vault or Bitwarden",
+		Use:     "kctx",
+		Short:   "Ephemeral kubeconfig switcher via Vault or Bitwarden",
+		Version: version.String(),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			cfg, err = config.Load(cfgFile)
@@ -55,13 +56,13 @@ func rootCmd() *cobra.Command {
 	root.PersistentFlags().BoolVar(&verbose, "verbose", false, "Enable debug logging (shorthand for --log-level=debug)")
 	root.PersistentFlags().StringVar(&cfgFile, "config", "", "Config file path (default: $XDG_CONFIG_HOME/renv/config.yaml)")
 	root.PersistentFlags().StringVar(&logLevel, "log-level", "", "Log level: debug, info, warn, error")
+	root.SetVersionTemplate("{{.Name}} {{.Version}}\n")
 
 	root.AddCommand(
 		switchCmd(&cfg),
 		unloadCmd(),
 		statusCmd(),
 		clearCacheCmd(),
-		versionCmd(),
 		shellInitCmd(),
 	)
 	return root
@@ -181,16 +182,6 @@ func clearCacheCmd() *cobra.Command {
 			cache := secrets.NewCache()
 			uid := fmt.Sprintf("%d", os.Getuid())
 			return cache.Clear(uid)
-		},
-	}
-}
-
-func versionCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "version",
-		Short: "Print version",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("kctx %s\n", version.String())
 		},
 	}
 }

--- a/cmd/renv/main.go
+++ b/cmd/renv/main.go
@@ -32,8 +32,9 @@ func rootCmd() *cobra.Command {
 	var cfg config.Config
 
 	root := &cobra.Command{
-		Use:   "renv",
-		Short: "Resolve secret references in .env and YAML files",
+		Use:     "renv",
+		Short:   "Resolve secret references in .env and YAML files",
+		Version: version.String(),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			cfg, err = config.Load(cfgFile)
@@ -73,6 +74,7 @@ func rootCmd() *cobra.Command {
 	root.PersistentFlags().StringVar(&passwordGracePeriod, "password-grace-period", "", "Grace period before re-prompting for local password (e.g. 1m, 5m, 1h). When set, each terminal authenticates independently; re-prompt is skipped within the period.")
 	root.PersistentFlags().StringVar(&cfgFile, "config", "", "Config file path (default: $XDG_CONFIG_HOME/renv/config.yaml)")
 	root.PersistentFlags().StringVar(&logLevel, "log-level", "", "Log level: debug, info, warn, error")
+	root.SetVersionTemplate("{{.Name}} {{.Version}}\n")
 
 	root.AddCommand(
 		resolveCmd(&noCache, &cfg),
@@ -81,7 +83,6 @@ func rootCmd() *cobra.Command {
 		yamlCmd(&cfg),
 		clearCacheCmd(),
 		statusCmd(),
-		versionCmd(),
 		unloadCmd(),
 	)
 	return root
@@ -377,16 +378,6 @@ func statusCmd() *cobra.Command {
 				fmt.Printf("%s (age: %s)\n", f, ages[i])
 			}
 			return nil
-		},
-	}
-}
-
-func versionCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "version",
-		Short: "Print version",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("renv %s\n", version.String())
 		},
 	}
 }

--- a/docs/kctx.md
+++ b/docs/kctx.md
@@ -47,7 +47,7 @@ kctx() {
 
 `switch` and `unload` output shell statements (`export KUBECONFIG=…` / `unset KUBECONFIG`)
 that are `eval`'d so they take effect in the current shell. All other subcommands
-(`status`, `version`, `clear-cache`, …) run the binary directly.
+(`status`, `clear-cache`, …) run the binary directly.
 
 ## Usage
 
@@ -58,7 +58,7 @@ kctx switch prod bw://kube/prod-config   # fetch from Bitwarden (see below)
 kctx unload                              # unset KUBECONFIG and remove tmpfile
 kctx status                              # show current KUBECONFIG path
 kctx clear-cache                         # remove all kctx cache files
-kctx version                             # print version
+kctx --version                           # print version
 ```
 
 `kctx switch` automatically registers `trap 'kctx unload' EXIT` so the kubeconfig is

--- a/docs/renv.md
+++ b/docs/renv.md
@@ -137,7 +137,7 @@ API_KEY=vault://secret/myapp#api_key
 | `renv yaml config.yaml --key database.password` | Extract single value |
 | `renv clear-cache` | Remove cache files and stored BW session (preserves var tracking) |
 | `renv status` | Show cache status |
-| `renv version` | Print version |
+| `renv --version` | Print version |
 
 ## URI formats
 

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,14 @@
         # `git tag v0.2.0 && echo -n 0.2.0 > VERSION` is the release workflow.
         releaseVersion = builtins.replaceStrings [ "\n" " " ] [ "" "" ] (builtins.readFile ./VERSION);
         versionPkg = "github.com/eficode/secure-handling-of-secrets/internal/version";
+
+        # self.shortRev is the 7-char git commit hash; falls back to "dirty" when the
+        # working tree has uncommitted changes (Nix won't set rev on a dirty tree).
+        commitHash = self.shortRev or "dirty";
+        # Dev builds embed the commit so `renv version` shows e.g. "0.1.0-dev+aeda2e9".
+        # Goreleaser handles tagged release builds separately (see .goreleaser.yaml).
+        nixVersion = "${releaseVersion}-dev+${commitHash}";
+
         common = {
           src = ./.;
           vendorHash = "sha256-toMUBMJ/Ky7HglGwhhLVHN+FzUWihwNfKS/XnGIe9aE=";
@@ -33,8 +41,8 @@
           subPackages = [ "cmd/renv" ];
           ldflags = [
             "-s" "-w"
-            "-X ${versionPkg}.Version=${releaseVersion}"
-            "-X ${versionPkg}.Commit=nix-build"
+            "-X ${versionPkg}.Version=${nixVersion}"
+            "-X ${versionPkg}.Commit=${commitHash}"
             "-X ${versionPkg}.BuildDate=unknown"
           ];
         });
@@ -45,8 +53,8 @@
           subPackages = [ "cmd/kctx" ];
           ldflags = [
             "-s" "-w"
-            "-X ${versionPkg}.Version=${releaseVersion}"
-            "-X ${versionPkg}.Commit=nix-build"
+            "-X ${versionPkg}.Version=${nixVersion}"
+            "-X ${versionPkg}.Commit=${commitHash}"
             "-X ${versionPkg}.BuildDate=unknown"
           ];
         });
@@ -58,8 +66,8 @@
           subPackages = [ "cmd/renv" "cmd/kctx" ];
           ldflags = [
             "-s" "-w"
-            "-X ${versionPkg}.Version=${releaseVersion}"
-            "-X ${versionPkg}.Commit=nix-build"
+            "-X ${versionPkg}.Version=${nixVersion}"
+            "-X ${versionPkg}.Commit=${commitHash}"
             "-X ${versionPkg}.BuildDate=unknown"
           ];
         });

--- a/flake.nix
+++ b/flake.nix
@@ -26,9 +26,10 @@
         # self.shortRev is the 7-char git commit hash; falls back to "dirty" when the
         # working tree has uncommitted changes (Nix won't set rev on a dirty tree).
         commitHash = self.shortRev or "dirty";
-        # Dev builds embed the commit so `renv version` shows e.g. "0.1.0-dev+aeda2e9".
+        # Dev builds embed the commit so `renv --version` shows e.g. "0.1.0-dev+aeda2e9".
         # Goreleaser handles tagged release builds separately (see .goreleaser.yaml).
         nixVersion = "${releaseVersion}-dev+${commitHash}";
+        buildDate = self.lastModifiedDate or "unknown";
 
         common = {
           src = ./.;
@@ -43,7 +44,7 @@
             "-s" "-w"
             "-X ${versionPkg}.Version=${nixVersion}"
             "-X ${versionPkg}.Commit=${commitHash}"
-            "-X ${versionPkg}.BuildDate=unknown"
+            "-X ${versionPkg}.BuildDate=${buildDate}"
           ];
         });
 
@@ -55,7 +56,7 @@
             "-s" "-w"
             "-X ${versionPkg}.Version=${nixVersion}"
             "-X ${versionPkg}.Commit=${commitHash}"
-            "-X ${versionPkg}.BuildDate=unknown"
+            "-X ${versionPkg}.BuildDate=${buildDate}"
           ];
         });
 
@@ -68,7 +69,7 @@
             "-s" "-w"
             "-X ${versionPkg}.Version=${nixVersion}"
             "-X ${versionPkg}.Commit=${commitHash}"
-            "-X ${versionPkg}.BuildDate=unknown"
+            "-X ${versionPkg}.BuildDate=${buildDate}"
           ];
         });
       in

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,12 @@
         # Dev builds embed the commit so `renv --version` shows e.g. "0.1.0-dev+aeda2e9".
         # Goreleaser handles tagged release builds separately (see .goreleaser.yaml).
         nixVersion = "${releaseVersion}-dev+${commitHash}";
-        buildDate = self.lastModifiedDate or "unknown";
+        # self.lastModifiedDate is "YYYYMMDDHHmmss"; reformat to ISO 8601 to match `make build` output.
+        buildDate =
+          let raw = self.lastModifiedDate or "unknown"; in
+          if raw == "unknown" then "unknown"
+          else
+            "${builtins.substring 0 4 raw}-${builtins.substring 4 2 raw}-${builtins.substring 6 2 raw}T${builtins.substring 8 2 raw}:${builtins.substring 10 2 raw}:${builtins.substring 12 2 raw}Z";
 
         common = {
           src = ./.;


### PR DESCRIPTION
- [x] Fix Makefile: strip leading `v` from tag in clean builds to match GoReleaser format
- [x] Fix flake.nix: update comment from `renv version` to `renv --version`
- [x] Fix flake.nix: use `self.lastModifiedDate` for BuildDate in all three packages
- [x] Fix flake.nix: reformat `self.lastModifiedDate` (`YYYYMMDDHHmmss`) to ISO 8601 (`YYYY-MM-DDTHH:MM:SSZ`) to match `make build` output
- [x] Update docs/renv.md: replace `renv version` with `renv --version`
- [x] Update docs/kctx.md: replace `kctx version` with `kctx --version` and remove subcommand references