### PR TITLE
feat(kctx): named kubeconfig loading with kctx load / kctx switch

### DIFF
--- a/cmd/kctx/main.go
+++ b/cmd/kctx/main.go
@@ -92,9 +92,8 @@ func loadCmd(cfg *config.Config) *cobra.Command {
 named store so that 'kctx switch <name>' can load it without re-fetching.
 
 Place multiple kctx load calls in your .env file to pre-load all configs.
-The local password and BW password are prompted on first use; subsequent
-calls in the same shell session reuse the local password set in
-RENV_LOCAL_PASSWORD.
+Both the local password and the Bitwarden password are prompted fresh on
+every call — no passwords are persisted or shared between invocations.
 
 Examples:
   kctx load prod bw://kubernetes/prod
@@ -403,18 +402,11 @@ kctx() {
   case "$1" in
     load)
       # Pre-load a named kubeconfig from Bitwarden or Vault.
-      # Prompt for the local password once per shell session and export it so
-      # subsequent 'kctx load' calls in the same .env source don't re-prompt.
+      # Passwords are prompted fresh on every call — no caching or persistence.
       #
       # Usage in .env:
       #   kctx load prod     bw://kubernetes/prod
       #   kctx load staging  bw://kubernetes/staging
-      if [ -z "${RENV_LOCAL_PASSWORD:-}" ]; then
-        printf "Local cache password: " >&2
-        read -rs _KCTX_LP </dev/tty; printf "\n" >&2
-        export RENV_LOCAL_PASSWORD="$_KCTX_LP"
-        unset _KCTX_LP
-      fi
       command kctx load "${@:2}"
       ;;
     switch)

--- a/cmd/kctx/main.go
+++ b/cmd/kctx/main.go
@@ -65,6 +65,7 @@ func rootCmd() *cobra.Command {
 	root.SetVersionTemplate("{{.Name}} {{.Version}}\n")
 
 	root.AddCommand(
+		loadCmd(&cfg),
 		switchCmd(&cfg),
 		unloadCmd(),
 		statusCmd(),
@@ -75,31 +76,47 @@ func rootCmd() *cobra.Command {
 	return root
 }
 
-func switchCmd(cfg *config.Config) *cobra.Command {
+// loadCmd fetches a kubeconfig from Bitwarden or Vault and stores it in the
+// named store, encrypted with the local password. Designed to be called from
+// a .env file so multiple configs can be pre-loaded before switching.
+//
+// Usage:
+//
+//	kctx load prod bw://folder/item
+//	kctx load staging vault://secret/kubeconfig/staging
+func loadCmd(cfg *config.Config) *cobra.Command {
 	return &cobra.Command{
-		Use:   "switch <env> [vault-path|bw://item]",
-		Short: "Fetch kubeconfig, write to tmpfile, print KUBECONFIG export",
-		Args:  cobra.RangeArgs(1, 2),
+		Use:   "load <name> <bw://item|vault-path>",
+		Short: "Fetch a kubeconfig and cache it under a local name",
+		Long: `Fetch a kubeconfig from Bitwarden or Vault and encrypt it in the local
+named store so that 'kctx switch <name>' can load it without re-fetching.
+
+Place multiple kctx load calls in your .env file to pre-load all configs.
+The local password and BW password are prompted on first use; subsequent
+calls in the same shell session reuse the local password set in
+RENV_LOCAL_PASSWORD.
+
+Examples:
+  kctx load prod bw://kubernetes/prod
+  kctx load staging vault://secret/kubeconfig/staging`,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			env := args[0]
-			source := ""
-			if len(args) > 1 {
-				source = args[1]
+			name := args[0]
+			source := args[1]
+
+			if err := kubeconfig.ValidateStoreName(name); err != nil {
+				return err
 			}
-			slog.Debug("switching kubeconfig", "env", env, "source", source)
+
+			slog.Debug("loading kubeconfig", "name", name, "source", source)
+
+			uid := fmt.Sprintf("%d", os.Getuid())
+			store := kubeconfig.NewNamedStore()
 
 			var kubeconfigData []byte
+			var localPassword string
 
-			if source == "" || source == env {
-				// Default: try vault path based on env name
-				vaultRef := secrets.VaultRef{Path: "secret/kubeconfig/" + env, Field: "kubeconfig"}
-				vc := &secrets.VaultClient{Timeout: cfg.VaultTimeout()}
-				val, verr := vc.Resolve(vaultRef)
-				if verr != nil {
-					return fmt.Errorf("fetching kubeconfig for %q: %w", env, verr)
-				}
-				kubeconfigData = []byte(val)
-			} else if len(source) > 5 && source[:5] == "bw://" {
+			if strings.HasPrefix(source, "bw://") {
 				ref, err := secrets.ParseBWRef(source)
 				if err != nil {
 					return err
@@ -115,15 +132,97 @@ func switchCmd(cfg *config.Config) *cobra.Command {
 					return bwerr
 				}
 				kubeconfigData = []byte(val)
+				localPassword = bwClient.LocalPassword
 			} else {
-				// Treat as vault path
-				vaultRef := secrets.VaultRef{Path: source, Field: "kubeconfig"}
+				// Treat as Vault path; field defaults to "kubeconfig".
+				field := "kubeconfig"
+				path := source
+				if strings.HasPrefix(source, "vault://") {
+					path = strings.TrimPrefix(source, "vault://")
+				}
+				vaultRef := secrets.VaultRef{Path: path, Field: field}
 				vc := &secrets.VaultClient{Timeout: cfg.VaultTimeout()}
 				val, verr := vc.Resolve(vaultRef)
 				if verr != nil {
 					return verr
 				}
 				kubeconfigData = []byte(val)
+				// Vault doesn't use local password; prompt separately.
+				lp, lperr := secrets.ReadLocalPassword()
+				if lperr != nil {
+					return lperr
+				}
+				localPassword = lp
+			}
+
+			if err := store.Put(uid, name, localPassword, kubeconfigData); err != nil {
+				return fmt.Errorf("storing kubeconfig %q: %w", name, err)
+			}
+
+			ui.Success(os.Stderr, fmt.Sprintf("Loaded kubeconfig: %s", ui.Bold(os.Stderr, name)))
+			return nil
+		},
+	}
+}
+
+// switchCmd loads a pre-cached (named) kubeconfig and exports KUBECONFIG.
+// If the name is not found in the local named store, it falls back to an
+// explicit bw:// or vault path source if one is provided.
+func switchCmd(cfg *config.Config) *cobra.Command {
+	return &cobra.Command{
+		Use:   "switch <name> [bw://item|vault-path]",
+		Short: "Switch to a named kubeconfig (or fetch one if a source is given)",
+		Long: `Switch KUBECONFIG to a named kubeconfig previously loaded with 'kctx load'.
+
+If the named kubeconfig is not in the local store, a source (bw:// or vault
+path) may be provided to fetch it on the fly.
+
+Examples:
+  kctx switch prod                          # use pre-loaded 'prod'
+  kctx switch staging bw://k8s/staging      # fetch directly if not pre-loaded`,
+		Args: cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			source := ""
+			if len(args) > 1 {
+				source = args[1]
+			}
+			slog.Debug("switching kubeconfig", "name", name, "source", source)
+
+			uid := fmt.Sprintf("%d", os.Getuid())
+			store := kubeconfig.NewNamedStore()
+
+			var kubeconfigData []byte
+
+			// Try the named store first.
+			if err := kubeconfig.ValidateStoreName(name); err == nil {
+				lp, lperr := secrets.ReadLocalPassword()
+				if lperr != nil {
+					return lperr
+				}
+				data, err := store.Get(uid, name, lp)
+				if err != nil {
+					return fmt.Errorf("reading named kubeconfig %q: %w", name, err)
+				}
+				if data != nil {
+					kubeconfigData = data
+				}
+			}
+
+			// Fall back to an explicit source if the named store had no entry.
+			if kubeconfigData == nil {
+				if source == "" {
+					return fmt.Errorf(
+						"no pre-loaded kubeconfig named %q found\n"+
+							"Run: kctx load %s <bw://item|vault-path>",
+						name, name,
+					)
+				}
+				var err error
+				kubeconfigData, err = fetchKubeconfig(cfg, source)
+				if err != nil {
+					return fmt.Errorf("fetching kubeconfig for %q: %w", name, err)
+				}
 			}
 
 			path, werr := kubeconfig.WriteKubeconfig(kubeconfigData)
@@ -135,11 +234,41 @@ func switchCmd(cfg *config.Config) *cobra.Command {
 			fmt.Printf("trap 'kctx unload' EXIT\n")
 
 			// Feedback to stderr — stdout must stay clean for eval.
-			ui.Success(os.Stderr, fmt.Sprintf("Switched to kubeconfig: %s", ui.Bold(os.Stderr, env)))
+			ui.Success(os.Stderr, fmt.Sprintf("Switched to kubeconfig: %s", ui.Bold(os.Stderr, name)))
 			ui.Item(os.Stderr, "KUBECONFIG", path)
 			return nil
 		},
 	}
+}
+
+// fetchKubeconfig fetches kubeconfig bytes from the given bw:// or vault source.
+func fetchKubeconfig(cfg *config.Config, source string) ([]byte, error) {
+	if strings.HasPrefix(source, "bw://") {
+		ref, err := secrets.ParseBWRef(source)
+		if err != nil {
+			return nil, err
+		}
+		cache := secrets.NewCache()
+		cache.MaxAge = cfg.CacheMaxAge()
+		bwClient := &secrets.BWClient{
+			Cache:   cache,
+			Timeout: cfg.BitwardenTimeout(),
+		}
+		val, bwerr := bwClient.Resolve(ref)
+		if bwerr != nil {
+			return nil, bwerr
+		}
+		return []byte(val), nil
+	}
+	// Treat as Vault path.
+	path := strings.TrimPrefix(source, "vault://")
+	vaultRef := secrets.VaultRef{Path: path, Field: "kubeconfig"}
+	vc := &secrets.VaultClient{Timeout: cfg.VaultTimeout()}
+	val, verr := vc.Resolve(vaultRef)
+	if verr != nil {
+		return nil, verr
+	}
+	return []byte(val), nil
 }
 
 func unloadCmd() *cobra.Command {
@@ -180,7 +309,7 @@ func isManagedKubeconfig(path string) bool {
 func statusCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
-		Short: "Show current KUBECONFIG and kubectl context",
+		Short: "Show current KUBECONFIG, kubectl context, and loaded kubeconfigs",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := os.Stdout
 			ui.Header(w, "Kubeconfig")
@@ -203,6 +332,19 @@ func statusCmd() *cobra.Command {
 					ui.Item(w, "Current context", ui.Bold(w, ctx))
 				}
 			}
+
+			// Show named kubeconfigs available in the local store.
+			uid := fmt.Sprintf("%d", os.Getuid())
+			store := kubeconfig.NewNamedStore()
+			names, err := store.List(uid)
+			if err != nil {
+				slog.Warn("listing named kubeconfigs", "err", err)
+			} else if len(names) > 0 {
+				ui.Header(w, "Loaded kubeconfigs (use 'kctx switch <name>')")
+				for _, n := range names {
+					ui.Item(w, "•", n)
+				}
+			}
 			return nil
 		},
 	}
@@ -222,13 +364,20 @@ func currentKubectlContext() string {
 func clearCacheCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "clear-cache",
-		Short: "Remove all kctx cache files",
+		Short: "Remove all kctx cache files and named kubeconfigs",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cache := secrets.NewCache()
 			uid := fmt.Sprintf("%d", os.Getuid())
+
+			cache := secrets.NewCache()
 			if err := cache.Clear(uid); err != nil {
 				return err
 			}
+
+			store := kubeconfig.NewNamedStore()
+			if err := store.Clear(uid); err != nil {
+				return err
+			}
+
 			ui.Success(os.Stderr, "Cache cleared")
 			return nil
 		},
@@ -252,8 +401,24 @@ func kctxShellSnippet() string {
 
 kctx() {
   case "$1" in
+    load)
+      # Pre-load a named kubeconfig from Bitwarden or Vault.
+      # Prompt for the local password once per shell session and export it so
+      # subsequent 'kctx load' calls in the same .env source don't re-prompt.
+      #
+      # Usage in .env:
+      #   kctx load prod     bw://kubernetes/prod
+      #   kctx load staging  bw://kubernetes/staging
+      if [ -z "${RENV_LOCAL_PASSWORD:-}" ]; then
+        printf "Local cache password: " >&2
+        read -rs _KCTX_LP </dev/tty; printf "\n" >&2
+        export RENV_LOCAL_PASSWORD="$_KCTX_LP"
+        unset _KCTX_LP
+      fi
+      command kctx load "${@:2}"
+      ;;
     switch)
-      # Explicit subcommand: kctx switch <env> [source] [flags]
+      # Explicit subcommand: kctx switch <name> [source] [flags]
       # Only eval and arm the EXIT trap when switch succeeds; a failing switch
       # must not replace the shell-init EXIT trap or unload a working kubeconfig.
       if _kctx_out="$(command kctx switch "${@:2}")"; then
@@ -278,7 +443,7 @@ kctx() {
       command kctx
       ;;
     *)
-      # Positional shorthand: kctx <env> [source] → kctx switch <env> [source]
+      # Positional shorthand: kctx <name> [source] → kctx switch <name> [source]
       if _kctx_out="$(command kctx switch "$@")"; then
         eval "$_kctx_out"
         _KCTX_LAST_UNLOAD_TOKEN="$(_kctx_unload_token 2>/dev/null || true)"
@@ -363,11 +528,13 @@ On Windows, event hooks are not yet implemented.`,
 				return fmt.Errorf("registering lock hook: %w", err)
 			}
 
-			// On sleep: clear the encrypted cache as well.
+			// On sleep: clear the encrypted cache and named kubeconfig store as well.
 			if err := hook.RegisterSleep(func() error {
 				slog.Debug("cleanup: clearing kctx cache and managed kubeconfigs on sleep")
 				cache := secrets.NewCache()
 				_ = cache.Clear(uid)
+				store := kubeconfig.NewNamedStore()
+				_ = store.Clear(uid)
 				kubeconfig.ClearManaged()
 				_ = kubeconfig.RequestUnload(uid)
 				return nil

--- a/cmd/kctx/main.go
+++ b/cmd/kctx/main.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 
@@ -133,13 +134,29 @@ Examples:
 				kubeconfigData = []byte(val)
 				localPassword = bwClient.LocalPassword
 			} else {
-				// Treat as Vault path; field defaults to "kubeconfig".
-				field := "kubeconfig"
-				path := source
+				// Parse vault:// URI (with optional #field fragment) or treat as raw path.
+				var vaultRef secrets.VaultRef
 				if strings.HasPrefix(source, "vault://") {
-					path = strings.TrimPrefix(source, "vault://")
+					if strings.Contains(source, "#") {
+						// Fragment present — parse it fully.
+						ref, err := secrets.ParseVaultRef(source)
+						if err != nil {
+							return err
+						}
+						if ref.Field == "" {
+							ref.Field = "kubeconfig"
+						}
+						vaultRef = ref
+					} else {
+						// No fragment — default field to "kubeconfig".
+						vaultRef = secrets.VaultRef{
+							Path:  strings.TrimPrefix(source, "vault://"),
+							Field: "kubeconfig",
+						}
+					}
+				} else {
+					vaultRef = secrets.VaultRef{Path: source, Field: "kubeconfig"}
 				}
-				vaultRef := secrets.VaultRef{Path: path, Field: field}
 				vc := &secrets.VaultClient{Timeout: cfg.VaultTimeout()}
 				val, verr := vc.Resolve(vaultRef)
 				if verr != nil {
@@ -259,9 +276,29 @@ func fetchKubeconfig(cfg *config.Config, source string) ([]byte, error) {
 		}
 		return []byte(val), nil
 	}
-	// Treat as Vault path.
-	path := strings.TrimPrefix(source, "vault://")
-	vaultRef := secrets.VaultRef{Path: path, Field: "kubeconfig"}
+	// Parse vault:// URI (with optional #field fragment) or treat as raw path.
+	var vaultRef secrets.VaultRef
+	if strings.HasPrefix(source, "vault://") {
+		if strings.Contains(source, "#") {
+			// Fragment present — parse it fully.
+			ref, err := secrets.ParseVaultRef(source)
+			if err != nil {
+				return nil, err
+			}
+			if ref.Field == "" {
+				ref.Field = "kubeconfig"
+			}
+			vaultRef = ref
+		} else {
+			// No fragment — default field to "kubeconfig".
+			vaultRef = secrets.VaultRef{
+				Path:  strings.TrimPrefix(source, "vault://"),
+				Field: "kubeconfig",
+			}
+		}
+	} else {
+		vaultRef = secrets.VaultRef{Path: source, Field: "kubeconfig"}
+	}
 	vc := &secrets.VaultClient{Timeout: cfg.VaultTimeout()}
 	val, verr := vc.Resolve(vaultRef)
 	if verr != nil {
@@ -339,10 +376,9 @@ func statusCmd() *cobra.Command {
 			if err != nil {
 				slog.Warn("listing named kubeconfigs", "err", err)
 			} else if len(names) > 0 {
+				sort.Strings(names)
 				ui.Header(w, "Loaded kubeconfigs (use 'kctx switch <name>')")
-				for _, n := range names {
-					ui.Item(w, "•", n)
-				}
+				ui.List(w, names)
 			}
 			return nil
 		},

--- a/cmd/renv/main.go
+++ b/cmd/renv/main.go
@@ -69,6 +69,14 @@ func rootCmd() *cobra.Command {
 	root.PersistentFlags().StringVar(&logLevel, "log-level", "", "Log level: debug, info, warn, error")
 	root.SetVersionTemplate("{{.Name}} {{.Version}}\n")
 
+	// Deprecated flags kept for backwards compatibility — they are now no-ops.
+	var ignoredBool bool
+	var ignoredString string
+	root.PersistentFlags().BoolVar(&ignoredBool, "isolated", false, "Deprecated: no longer has any effect")
+	root.PersistentFlags().StringVar(&ignoredString, "password-grace-period", "", "Deprecated: no longer has any effect")
+	_ = root.PersistentFlags().MarkDeprecated("isolated", "this flag no longer has any effect and will be removed in a future release")
+	_ = root.PersistentFlags().MarkDeprecated("password-grace-period", "this flag no longer has any effect and will be removed in a future release")
+
 	root.AddCommand(
 		resolveCmd(&noCache, &cfg),
 		execCmd(&noCache, &cfg),

--- a/cmd/renv/main.go
+++ b/cmd/renv/main.go
@@ -30,8 +30,6 @@ func main() {
 func rootCmd() *cobra.Command {
 	var verbose bool
 	var noCache bool
-	var isolated bool
-	var passwordGracePeriod string
 	var cfgFile string
 	var logLevel string
 	var cfg config.Config
@@ -53,19 +51,11 @@ func rootCmd() *cobra.Command {
 			if verbose {
 				cfg.Log.Level = "debug"
 			}
-			if cmd.Root().PersistentFlags().Changed("isolated") {
-				cfg.Cache.Isolated = isolated
-			}
-			if cmd.Root().PersistentFlags().Changed("password-grace-period") {
-				cfg.Cache.PasswordGracePeriod = passwordGracePeriod
-			}
 			logger.Init(cfg.Log.Level, cfg.Log.Format)
 			slog.Debug("config loaded",
 				"log_level", cfg.Log.Level,
 				"log_format", cfg.Log.Format,
 				"cache_max_age", cfg.Cache.MaxAge,
-				"cache_isolated", cfg.Cache.Isolated,
-				"cache_password_grace_period", cfg.Cache.PasswordGracePeriod,
 				"timeout_bitwarden", cfg.Timeouts.Bitwarden,
 				"timeout_vault", cfg.Timeouts.Vault,
 			)
@@ -75,8 +65,6 @@ func rootCmd() *cobra.Command {
 
 	root.PersistentFlags().BoolVar(&verbose, "verbose", false, "Enable debug logging (shorthand for --log-level=debug)")
 	root.PersistentFlags().BoolVar(&noCache, "no-cache", false, "Disable encrypted cache")
-	root.PersistentFlags().BoolVar(&isolated, "isolated", false, "Require local password in each terminal (disable cross-terminal sharing)")
-	root.PersistentFlags().StringVar(&passwordGracePeriod, "password-grace-period", "", "Grace period before re-prompting for local password (e.g. 1m, 5m, 1h). When set, each terminal authenticates independently; re-prompt is skipped within the period.")
 	root.PersistentFlags().StringVar(&cfgFile, "config", "", "Config file path (default: $XDG_CONFIG_HOME/renv/config.yaml)")
 	root.PersistentFlags().StringVar(&logLevel, "log-level", "", "Log level: debug, info, warn, error")
 	root.SetVersionTemplate("{{.Name}} {{.Version}}\n")
@@ -101,10 +89,8 @@ func newClients(noCache bool, cfg *config.Config) (*secrets.Cache, *secrets.BWCl
 		cache.Disabled = true
 	}
 	bwClient := &secrets.BWClient{
-		Cache:               cache,
-		Timeout:             cfg.BitwardenTimeout(),
-		Isolated:            cfg.Cache.Isolated,
-		PasswordGracePeriod: cfg.CachePasswordGracePeriod(),
+		Cache:   cache,
+		Timeout: cfg.BitwardenTimeout(),
 	}
 	vaultClient := &secrets.VaultClient{Timeout: cfg.VaultTimeout()}
 	return cache, bwClient, vaultClient
@@ -491,16 +477,6 @@ func statusCmd() *cobra.Command {
 					ui.Item(w, f, ageStr)
 				}
 			}
-
-			// Local password stored?
-			lp, _ := secrets.LoadStoredLocalPassword(uid)
-			lpStatus := ui.Gray(w, "not stored")
-			if lp != "" {
-				lpStatus = ui.Green(w, "stored")
-			}
-			fmt.Fprintln(w)
-			ui.Header(w, "Session")
-			ui.Item(w, "Local password", lpStatus)
 
 			return nil
 		},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,24 +35,6 @@ type LogConfig struct {
 type CacheConfig struct {
 	// MaxAge is the maximum age of cached Bitwarden folder items (Go duration string).
 	MaxAge string `yaml:"max_age"`
-	// Isolated disables cross-terminal LocalPassword sharing. When false (default),
-	// the local cache password is saved to /dev/shm after the first prompt so other
-	// terminals can reuse the encrypted cache without being prompted again. Set to
-	// true to require each terminal to provide the password independently.
-	Isolated bool `yaml:"isolated"`
-	// PasswordGracePeriod is how long after a successful local-password prompt the
-	// stored key remains valid without re-prompting (Go duration string, e.g. "1m").
-	//
-	// When 0 (the default) the old behaviour applies: --isolated controls whether the
-	// password is shared across terminals at all (no expiry).
-	//
-	// When > 0:
-	//   - The password store is keyed per terminal session (parent shell PID), so
-	//     each new terminal always prompts at least once.
-	//   - Within the grace period the same terminal re-loads without a prompt.
-	//   - After the grace period the stored key is deleted and the prompt re-appears.
-	//   - The encrypted cache files themselves are still shared across terminals.
-	PasswordGracePeriod string `yaml:"password_grace_period"`
 }
 
 // TimeoutConfig controls subprocess call timeouts.
@@ -127,12 +109,6 @@ func applyEnv(cfg *Config) {
 	if v := os.Getenv("RENV_CACHE_MAX_AGE"); v != "" {
 		cfg.Cache.MaxAge = v
 	}
-	if v := os.Getenv("RENV_ISOLATED"); v != "" {
-		cfg.Cache.Isolated = v == "true" || v == "1" || v == "yes"
-	}
-	if v := os.Getenv("RENV_PASSWORD_GRACE_PERIOD"); v != "" {
-		cfg.Cache.PasswordGracePeriod = v
-	}
 	if v := os.Getenv("RENV_TIMEOUT_BITWARDEN"); v != "" {
 		cfg.Timeouts.Bitwarden = v
 	}
@@ -144,12 +120,6 @@ func applyEnv(cfg *Config) {
 // CacheMaxAge parses and returns the cache max-age duration.
 func (c *Config) CacheMaxAge() time.Duration {
 	return parseDuration(c.Cache.MaxAge, 8*time.Hour)
-}
-
-// CachePasswordGracePeriod parses and returns the password grace period duration.
-// Returns 0 when unset, meaning the old shared-store behaviour applies.
-func (c *Config) CachePasswordGracePeriod() time.Duration {
-	return parseDuration(c.Cache.PasswordGracePeriod, 0)
 }
 
 // BitwardenTimeout parses and returns the Bitwarden subprocess timeout.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -50,7 +50,6 @@ log:
   format: json
 cache:
   max_age: 2h
-  isolated: true
 timeouts:
   bitwarden: 60s
   vault: 45s
@@ -71,9 +70,6 @@ timeouts:
 	}
 	if cfg.Cache.MaxAge != "2h" {
 		t.Errorf("Cache.MaxAge: got %q, want %q", cfg.Cache.MaxAge, "2h")
-	}
-	if !cfg.Cache.Isolated {
-		t.Error("Cache.Isolated: expected true")
 	}
 	if cfg.Timeouts.Bitwarden != "60s" {
 		t.Errorf("Timeouts.Bitwarden: got %q, want %q", cfg.Timeouts.Bitwarden, "60s")
@@ -111,13 +107,11 @@ func TestLoad_EmptyPathUsesDefault(t *testing.T) {
 func TestApplyEnv(t *testing.T) {
 	// Isolate env var changes to this test.
 	vars := map[string]string{
-		"RENV_LOG_LEVEL":             "debug",
-		"RENV_LOG_FORMAT":            "json",
-		"RENV_CACHE_MAX_AGE":         "4h",
-		"RENV_ISOLATED":              "true",
-		"RENV_PASSWORD_GRACE_PERIOD": "5m",
-		"RENV_TIMEOUT_BITWARDEN":     "10s",
-		"RENV_TIMEOUT_VAULT":         "15s",
+		"RENV_LOG_LEVEL":         "debug",
+		"RENV_LOG_FORMAT":        "json",
+		"RENV_CACHE_MAX_AGE":     "4h",
+		"RENV_TIMEOUT_BITWARDEN": "10s",
+		"RENV_TIMEOUT_VAULT":     "15s",
 	}
 	for k, v := range vars {
 		t.Setenv(k, v)
@@ -135,45 +129,11 @@ func TestApplyEnv(t *testing.T) {
 	if cfg.Cache.MaxAge != "4h" {
 		t.Errorf("Cache.MaxAge: got %q, want 4h", cfg.Cache.MaxAge)
 	}
-	if !cfg.Cache.Isolated {
-		t.Error("Cache.Isolated: expected true")
-	}
-	if cfg.Cache.PasswordGracePeriod != "5m" {
-		t.Errorf("Cache.PasswordGracePeriod: got %q, want 5m", cfg.Cache.PasswordGracePeriod)
-	}
 	if cfg.Timeouts.Bitwarden != "10s" {
 		t.Errorf("Timeouts.Bitwarden: got %q, want 10s", cfg.Timeouts.Bitwarden)
 	}
 	if cfg.Timeouts.Vault != "15s" {
 		t.Errorf("Timeouts.Vault: got %q, want 15s", cfg.Timeouts.Vault)
-	}
-}
-
-func TestApplyEnv_IsolatedValues(t *testing.T) {
-	tests := []struct {
-		val  string
-		want bool
-	}{
-		{"true", true},
-		{"1", true},
-		{"yes", true},
-		{"false", false},
-		{"0", false},
-		{"no", false},
-		{"", false}, // env var unset — handled by empty-string guard in applyEnv
-	}
-	for _, tt := range tests {
-		if tt.val == "" {
-			continue // applyEnv only applies when val != ""
-		}
-		t.Run(tt.val, func(t *testing.T) {
-			t.Setenv("RENV_ISOLATED", tt.val)
-			cfg := Defaults()
-			applyEnv(&cfg)
-			if cfg.Cache.Isolated != tt.want {
-				t.Errorf("RENV_ISOLATED=%q → Isolated=%v, want %v", tt.val, cfg.Cache.Isolated, tt.want)
-			}
-		})
 	}
 }
 
@@ -193,25 +153,6 @@ func TestCacheMaxAge(t *testing.T) {
 		got := cfg.CacheMaxAge()
 		if got != tt.want {
 			t.Errorf("CacheMaxAge(%q) = %v, want %v", tt.input, got, tt.want)
-		}
-	}
-}
-
-func TestCachePasswordGracePeriod(t *testing.T) {
-	tests := []struct {
-		input string
-		want  time.Duration
-	}{
-		{"5m", 5 * time.Minute},
-		{"", 0},    // fallback is 0
-		{"bad", 0}, // fallback on parse error
-	}
-	for _, tt := range tests {
-		cfg := Defaults()
-		cfg.Cache.PasswordGracePeriod = tt.input
-		got := cfg.CachePasswordGracePeriod()
-		if got != tt.want {
-			t.Errorf("CachePasswordGracePeriod(%q) = %v, want %v", tt.input, got, tt.want)
 		}
 	}
 }

--- a/internal/kubeconfig/store.go
+++ b/internal/kubeconfig/store.go
@@ -96,16 +96,40 @@ func (s *NamedStore) Put(uid, name, password string, data []byte) error {
 
 	path := s.storePath(uid, name)
 	slog.Debug("named store put", "path", path, "name", name)
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, storeFilePerms)
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-")
 	if err != nil {
-		return fmt.Errorf("store: opening file: %w", err)
+		return fmt.Errorf("store: creating temp file: %w", err)
 	}
-	defer f.Close()
+	tmpPath := tmp.Name()
+	cleanupTmp := true
+	defer func() {
+		if cleanupTmp {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(storeFilePerms); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("store: setting temp file permissions: %w", err)
+	}
 	for _, chunk := range [][]byte{salt, iv, ciphertext} {
-		if _, err := f.Write(chunk); err != nil {
-			return fmt.Errorf("store: writing data: %w", err)
+		if _, err := tmp.Write(chunk); err != nil {
+			_ = tmp.Close()
+			return fmt.Errorf("store: writing temp file: %w", err)
 		}
 	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("store: syncing temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("store: closing temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("store: replacing file atomically: %w", err)
+	}
+	cleanupTmp = false
 	return nil
 }
 

--- a/internal/kubeconfig/store.go
+++ b/internal/kubeconfig/store.go
@@ -1,0 +1,251 @@
+package kubeconfig
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+const (
+	storeKeyLen    = 32
+	storeSaltLen   = 32
+	storeIVLen     = 16
+	storeIter      = 100_000
+	storeFilePerms = 0600
+	storePrefix    = "kctx-kc-"
+)
+
+// validStoreName matches safe kubeconfig names (alphanumeric, dash, underscore, dot).
+var validStoreName = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
+// NamedStore stores named kubeconfig data, encrypted with a local password.
+// Files are stored as kctx-kc-<uid>-<name>.enc in /dev/shm (preferred) or /tmp.
+// Encryption: AES-256-CBC, key derived via PBKDF2-SHA256.
+type NamedStore struct {
+	Dir    string
+	MaxAge time.Duration
+}
+
+// NewNamedStore picks /dev/shm if available and writable, else /tmp.
+func NewNamedStore() *NamedStore {
+	dir := "/tmp"
+	if fi, err := os.Stat("/dev/shm"); err == nil && fi.IsDir() {
+		testPath := filepath.Join("/dev/shm", ".kctx-ns-test")
+		if f, err := os.OpenFile(testPath, os.O_CREATE|os.O_WRONLY, 0600); err == nil {
+			f.Close()
+			os.Remove(testPath)
+			dir = "/dev/shm"
+		}
+	}
+	return &NamedStore{Dir: dir, MaxAge: 8 * time.Hour}
+}
+
+// ValidateStoreName returns an error if name is empty or contains unsafe characters.
+func ValidateStoreName(name string) error {
+	if name == "" {
+		return fmt.Errorf("kubeconfig name must not be empty")
+	}
+	if !validStoreName.MatchString(name) {
+		return fmt.Errorf("invalid kubeconfig name %q: only [a-zA-Z0-9_.-] are allowed", name)
+	}
+	return nil
+}
+
+// storePath returns the on-disk path for a named kubeconfig.
+func (s *NamedStore) storePath(uid, name string) string {
+	return filepath.Join(s.Dir, storePrefix+uid+"-"+name+".enc")
+}
+
+// Put encrypts data and writes it as the named kubeconfig for uid.
+// Existing entries with the same name are overwritten.
+func (s *NamedStore) Put(uid, name, password string, data []byte) error {
+	if err := ValidateStoreName(name); err != nil {
+		return err
+	}
+
+	salt := make([]byte, storeSaltLen)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return fmt.Errorf("store: generating salt: %w", err)
+	}
+	iv := make([]byte, storeIVLen)
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		return fmt.Errorf("store: generating IV: %w", err)
+	}
+
+	key := pbkdf2.Key([]byte(password), salt, storeIter, storeKeyLen, sha256.New)
+	defer storeZeroBytes(key)
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return fmt.Errorf("store: creating cipher: %w", err)
+	}
+	padded := storePkcs7Pad(data, aes.BlockSize)
+	ciphertext := make([]byte, len(padded))
+	cipher.NewCBCEncrypter(block, iv).CryptBlocks(ciphertext, padded)
+
+	path := s.storePath(uid, name)
+	slog.Debug("named store put", "path", path, "name", name)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, storeFilePerms)
+	if err != nil {
+		return fmt.Errorf("store: opening file: %w", err)
+	}
+	defer f.Close()
+	for _, chunk := range [][]byte{salt, iv, ciphertext} {
+		if _, err := f.Write(chunk); err != nil {
+			return fmt.Errorf("store: writing data: %w", err)
+		}
+	}
+	return nil
+}
+
+// Get decrypts and returns the stored kubeconfig for uid/name.
+// Returns (nil, nil) on cache miss or expiry.
+func (s *NamedStore) Get(uid, name, password string) ([]byte, error) {
+	if err := ValidateStoreName(name); err != nil {
+		return nil, err
+	}
+	path := s.storePath(uid, name)
+	fi, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		slog.Debug("named store miss (not found)", "name", name)
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("store: stat: %w", err)
+	}
+	if s.MaxAge > 0 && time.Since(fi.ModTime()) > s.MaxAge {
+		slog.Debug("named store expired", "name", name, "age", time.Since(fi.ModTime()).Round(time.Second))
+		os.Remove(path)
+		return nil, nil
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("store: reading file: %w", err)
+	}
+	if len(raw) < storeSaltLen+storeIVLen+aes.BlockSize {
+		return nil, fmt.Errorf("store: file too short")
+	}
+
+	salt := raw[:storeSaltLen]
+	iv := raw[storeSaltLen : storeSaltLen+storeIVLen]
+	ciphertext := raw[storeSaltLen+storeIVLen:]
+
+	key := pbkdf2.Key([]byte(password), salt, storeIter, storeKeyLen, sha256.New)
+	defer storeZeroBytes(key)
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("store: creating cipher: %w", err)
+	}
+	if len(ciphertext)%aes.BlockSize != 0 {
+		return nil, fmt.Errorf("store: ciphertext not block-aligned")
+	}
+	plaintext := make([]byte, len(ciphertext))
+	cipher.NewCBCDecrypter(block, iv).CryptBlocks(plaintext, ciphertext)
+
+	unpadded, err := storePkcs7Unpad(plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("store: wrong password or corrupted data: %w", err)
+	}
+	return unpadded, nil
+}
+
+// List returns the names of all non-expired named kubeconfigs for uid.
+func (s *NamedStore) List(uid string) ([]string, error) {
+	pattern := filepath.Join(s.Dir, storePrefix+uid+"-*.enc")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("store: glob: %w", err)
+	}
+	prefix := storePrefix + uid + "-"
+	var names []string
+	for _, m := range matches {
+		base := filepath.Base(m)
+		name := strings.TrimPrefix(base, prefix)
+		name = strings.TrimSuffix(name, ".enc")
+		if !validStoreName.MatchString(name) {
+			continue
+		}
+		if s.MaxAge > 0 {
+			if fi, err := os.Stat(m); err == nil && time.Since(fi.ModTime()) > s.MaxAge {
+				os.Remove(m)
+				continue
+			}
+		}
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+// Remove deletes the named kubeconfig for uid. No error if it does not exist.
+func (s *NamedStore) Remove(uid, name string) error {
+	if err := ValidateStoreName(name); err != nil {
+		return err
+	}
+	path := s.storePath(uid, name)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("store: removing %s: %w", path, err)
+	}
+	return nil
+}
+
+// Clear removes all named kubeconfigs for uid.
+func (s *NamedStore) Clear(uid string) error {
+	pattern := filepath.Join(s.Dir, storePrefix+uid+"-*.enc")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return fmt.Errorf("store: glob: %w", err)
+	}
+	for _, m := range matches {
+		if err := os.Remove(m); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("store: removing %s: %w", m, err)
+		}
+	}
+	return nil
+}
+
+// --- crypto helpers (self-contained, matching the secrets/cache.go approach) ---
+
+func storeZeroBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+func storePkcs7Pad(data []byte, blockSize int) []byte {
+	padding := blockSize - len(data)%blockSize
+	padded := make([]byte, len(data)+padding)
+	copy(padded, data)
+	for i := len(data); i < len(padded); i++ {
+		padded[i] = byte(padding)
+	}
+	return padded
+}
+
+func storePkcs7Unpad(data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty data")
+	}
+	padding := int(data[len(data)-1])
+	if padding > aes.BlockSize || padding == 0 {
+		return nil, fmt.Errorf("invalid padding byte: %d", padding)
+	}
+	for i := len(data) - padding; i < len(data); i++ {
+		if data[i] != byte(padding) {
+			return nil, fmt.Errorf("invalid padding")
+		}
+	}
+	return data[:len(data)-padding], nil
+}

--- a/internal/kubeconfig/store_test.go
+++ b/internal/kubeconfig/store_test.go
@@ -62,14 +62,18 @@ func TestNamedStore_Get_Miss(t *testing.T) {
 
 func TestNamedStore_Get_Expired(t *testing.T) {
 	store, uid := newTestStore(t)
-	store.MaxAge = 1 * time.Millisecond
 
 	data := []byte("apiVersion: v1\n")
 	if err := store.Put(uid, "prod", "pw", data); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
 
-	time.Sleep(5 * time.Millisecond)
+	// Backdate the file mtime so the entry is already expired.
+	path := store.storePath(uid, "prod")
+	expiredAt := time.Now().Add(-2 * store.MaxAge)
+	if err := os.Chtimes(path, expiredAt, expiredAt); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
 
 	got, err := store.Get(uid, "prod", "pw")
 	if err != nil {
@@ -80,7 +84,6 @@ func TestNamedStore_Get_Expired(t *testing.T) {
 	}
 
 	// File should be removed.
-	path := store.storePath(uid, "prod")
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Errorf("expected expired file to be deleted")
 	}
@@ -134,14 +137,28 @@ func TestNamedStore_List(t *testing.T) {
 
 func TestNamedStore_List_ExcludesExpired(t *testing.T) {
 	dir := t.TempDir()
-	store := &NamedStore{Dir: dir, MaxAge: 1 * time.Millisecond}
+	store := &NamedStore{Dir: dir, MaxAge: time.Hour}
 	uid := "testuid"
 	pw := "pw"
 
 	if err := store.Put(uid, "old", pw, []byte("data")); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
-	time.Sleep(5 * time.Millisecond)
+
+	// Backdate all store files so the entry is already expired.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	expiredAt := time.Now().Add(-2 * store.MaxAge)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if err := os.Chtimes(filepath.Join(dir, entry.Name()), expiredAt, expiredAt); err != nil {
+			t.Fatalf("Chtimes %q: %v", entry.Name(), err)
+		}
+	}
 
 	names, err := store.List(uid)
 	if err != nil {

--- a/internal/kubeconfig/store_test.go
+++ b/internal/kubeconfig/store_test.go
@@ -1,0 +1,244 @@
+package kubeconfig
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+)
+
+func newTestStore(t *testing.T) (*NamedStore, string) {
+	t.Helper()
+	dir := t.TempDir()
+	store := &NamedStore{Dir: dir, MaxAge: 8 * time.Hour}
+	uid := "testuid"
+	return store, uid
+}
+
+func TestNamedStore_PutGet_RoundTrip(t *testing.T) {
+	store, uid := newTestStore(t)
+	data := []byte("apiVersion: v1\nclusters: []\n")
+	pw := "test-password"
+
+	if err := store.Put(uid, "prod", pw, data); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	got, err := store.Get(uid, "prod", pw)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Errorf("Get returned %q, want %q", got, data)
+	}
+}
+
+func TestNamedStore_Get_WrongPassword(t *testing.T) {
+	store, uid := newTestStore(t)
+	data := []byte("apiVersion: v1\n")
+
+	if err := store.Put(uid, "prod", "correct", data); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	_, err := store.Get(uid, "prod", "wrong")
+	if err == nil {
+		t.Fatal("expected error with wrong password, got nil")
+	}
+}
+
+func TestNamedStore_Get_Miss(t *testing.T) {
+	store, uid := newTestStore(t)
+
+	got, err := store.Get(uid, "nonexistent", "pw")
+	if err != nil {
+		t.Fatalf("unexpected error on miss: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil on miss, got %q", got)
+	}
+}
+
+func TestNamedStore_Get_Expired(t *testing.T) {
+	store, uid := newTestStore(t)
+	store.MaxAge = 1 * time.Millisecond
+
+	data := []byte("apiVersion: v1\n")
+	if err := store.Put(uid, "prod", "pw", data); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	time.Sleep(5 * time.Millisecond)
+
+	got, err := store.Get(uid, "prod", "pw")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for expired entry, got data")
+	}
+
+	// File should be removed.
+	path := store.storePath(uid, "prod")
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("expected expired file to be deleted")
+	}
+}
+
+func TestNamedStore_Put_Overwrite(t *testing.T) {
+	store, uid := newTestStore(t)
+	pw := "pw"
+
+	if err := store.Put(uid, "prod", pw, []byte("v1")); err != nil {
+		t.Fatalf("first Put: %v", err)
+	}
+	if err := store.Put(uid, "prod", pw, []byte("v2")); err != nil {
+		t.Fatalf("second Put: %v", err)
+	}
+
+	got, err := store.Get(uid, "prod", pw)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != "v2" {
+		t.Errorf("expected v2, got %q", got)
+	}
+}
+
+func TestNamedStore_List(t *testing.T) {
+	store, uid := newTestStore(t)
+	pw := "pw"
+
+	for _, name := range []string{"prod", "staging", "dev"} {
+		if err := store.Put(uid, name, pw, []byte("data")); err != nil {
+			t.Fatalf("Put %q: %v", name, err)
+		}
+	}
+
+	names, err := store.List(uid)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	sort.Strings(names)
+	want := []string{"dev", "prod", "staging"}
+	if len(names) != len(want) {
+		t.Fatalf("expected %v, got %v", want, names)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Errorf("names[%d] = %q, want %q", i, names[i], want[i])
+		}
+	}
+}
+
+func TestNamedStore_List_ExcludesExpired(t *testing.T) {
+	dir := t.TempDir()
+	store := &NamedStore{Dir: dir, MaxAge: 1 * time.Millisecond}
+	uid := "testuid"
+	pw := "pw"
+
+	if err := store.Put(uid, "old", pw, []byte("data")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	time.Sleep(5 * time.Millisecond)
+
+	names, err := store.List(uid)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(names) != 0 {
+		t.Errorf("expected 0 names after expiry, got %v", names)
+	}
+}
+
+func TestNamedStore_Remove(t *testing.T) {
+	store, uid := newTestStore(t)
+	pw := "pw"
+
+	if err := store.Put(uid, "prod", pw, []byte("data")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := store.Remove(uid, "prod"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	got, err := store.Get(uid, "prod", pw)
+	if err != nil {
+		t.Fatalf("Get after Remove: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil after Remove, got data")
+	}
+}
+
+func TestNamedStore_Remove_NotExist(t *testing.T) {
+	store, uid := newTestStore(t)
+	// Should not error if the file doesn't exist.
+	if err := store.Remove(uid, "nonexistent"); err != nil {
+		t.Fatalf("Remove non-existent: %v", err)
+	}
+}
+
+func TestNamedStore_Clear(t *testing.T) {
+	store, uid := newTestStore(t)
+	pw := "pw"
+
+	for _, name := range []string{"prod", "staging"} {
+		if err := store.Put(uid, name, pw, []byte("data")); err != nil {
+			t.Fatalf("Put %q: %v", name, err)
+		}
+	}
+	// A file belonging to a different uid — must NOT be removed.
+	otherFile := filepath.Join(store.Dir, storePrefix+"otheruid-prod.enc")
+	if err := os.WriteFile(otherFile, []byte("x"), 0600); err != nil {
+		t.Fatalf("creating other uid file: %v", err)
+	}
+
+	if err := store.Clear(uid); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+
+	names, _ := store.List(uid)
+	if len(names) != 0 {
+		t.Errorf("expected 0 names after Clear, got %v", names)
+	}
+
+	// Other uid file must still exist.
+	if _, err := os.Stat(otherFile); err != nil {
+		t.Errorf("other uid file was incorrectly removed: %v", err)
+	}
+}
+
+func TestValidateStoreName(t *testing.T) {
+	valid := []string{"prod", "staging", "my-cluster", "cluster_1", "a.b"}
+	for _, n := range valid {
+		if err := ValidateStoreName(n); err != nil {
+			t.Errorf("ValidateStoreName(%q) = %v, want nil", n, err)
+		}
+	}
+
+	invalid := []string{"", "has space", "has/slash", "has:colon", "../escape"}
+	for _, n := range invalid {
+		if err := ValidateStoreName(n); err == nil {
+			t.Errorf("ValidateStoreName(%q) = nil, want error", n)
+		}
+	}
+}
+
+func TestNamedStore_FileMode(t *testing.T) {
+	store, uid := newTestStore(t)
+
+	if err := store.Put(uid, "prod", "pw", []byte("data")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	path := store.storePath(uid, "prod")
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if fi.Mode().Perm() != 0600 {
+		t.Errorf("expected mode 0600, got %v", fi.Mode().Perm())
+	}
+}

--- a/internal/secrets/bitwarden.go
+++ b/internal/secrets/bitwarden.go
@@ -25,7 +25,7 @@ import (
 //     persisted to disk. Only needed on a cache miss or first access to a folder.
 //   - LocalPassword: a local session password used to encrypt/decrypt the cache
 //     files in /dev/shm. Prompted once per invocation (or sourced from
-//     RENV_LOCAL_PASSWORD). Never sent to Bitwarden.
+//     RENV_LOCAL_PASSWORD). Held in process memory only; never written to disk.
 //
 // Access flow:
 //  1. First access to a folder: prompt LocalPassword + BWPassword → fetch from BW
@@ -33,34 +33,10 @@ import (
 //  2. Subsequent access within cache TTL: prompt LocalPassword only → decrypt
 //     cache. No Bitwarden contact.
 //  3. Access after cache TTL expires: prompt LocalPassword + BWPassword → re-fetch.
-//
-// Local-password storage behaviour (when Isolated=false):
-//
-//   - PasswordGracePeriod == 0 (default): the LocalPassword is persisted to
-//     /dev/shm as a shared file (uid-keyed). All terminals of the same user can
-//     skip the prompt once any one of them has authenticated. The file never
-//     expires on its own — only renv clear-cache removes it.
-//
-//   - PasswordGracePeriod > 0: the LocalPassword is persisted to a per-terminal
-//     file (keyed by the parent shell PID). Each new terminal must authenticate at
-//     least once. Within the grace period the same terminal may reload without
-//     re-prompting. After the period the file is deleted and the prompt reappears.
-//     The encrypted cache files remain shared across all terminals.
-//
-// Set Isolated=true to disable all persistent storage and require a prompt on
-// every invocation, regardless of PasswordGracePeriod.
 type BWClient struct {
 	Cache         *Cache
 	BWPassword    string // cleared after bw unlock; used only for `bw unlock --raw`
-	LocalPassword string // used only for cache encryption; never sent to Bitwarden
-	// Isolated disables cross-terminal LocalPassword sharing. When false (default),
-	// the LocalPassword is saved to /dev/shm after the first prompt so other
-	// terminals can reuse the cache without prompting again.
-	Isolated bool
-	// PasswordGracePeriod is how long after a successful local-password prompt the
-	// stored key remains valid without re-prompting. When 0 (default) the shared
-	// store never expires. When > 0 the store is keyed per terminal (parent PID).
-	PasswordGracePeriod time.Duration
+	LocalPassword string // used only for cache encryption; never sent to Bitwarden; held in memory only
 	// Timeout caps each bw subprocess call. Zero uses the 30 s default.
 	Timeout time.Duration
 
@@ -79,9 +55,8 @@ func (c *BWClient) timeout() time.Duration {
 // ensureLocalPassword populates c.LocalPassword from (in order of precedence):
 //  1. c.LocalPassword already set
 //  2. RENV_LOCAL_PASSWORD env var
-//  3. Key store (shared or per-terminal, see PasswordGracePeriod), when Isolated=false
-//  4. Prompt on /dev/tty; on success, the password is saved to the key store
-//     (unless Isolated=true) so subsequent calls within the grace period skip it.
+//  3. Prompt on /dev/tty; password is stored in c.LocalPassword for the lifetime
+//     of this process only — never written to disk.
 func (c *BWClient) ensureLocalPassword() error {
 	if c.LocalPassword != "" {
 		return nil
@@ -89,15 +64,6 @@ func (c *BWClient) ensureLocalPassword() error {
 	if pw := os.Getenv("RENV_LOCAL_PASSWORD"); pw != "" {
 		c.LocalPassword = pw
 		return nil
-	}
-	uid := fmt.Sprintf("%d", os.Getuid())
-	if !c.Isolated {
-		path := c.keyStorePath(uid)
-		if pw, err := loadLocalPasswordFromPath(path, c.PasswordGracePeriod); err == nil && pw != "" {
-			slog.Debug("using stored local password", "path", path)
-			c.LocalPassword = pw
-			return nil
-		}
 	}
 	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
 	if err != nil {
@@ -111,74 +77,6 @@ func (c *BWClient) ensureLocalPassword() error {
 	}
 	fmt.Fprintln(tty)
 	c.LocalPassword = string(pwBytes)
-	if !c.Isolated {
-		path := c.keyStorePath(uid)
-		if err := saveLocalPasswordToPath(path, c.LocalPassword); err != nil {
-			slog.Debug("could not save local password to store", "error", err)
-		}
-	}
-	return nil
-}
-
-// keyStorePath returns the file path used to persist the local password.
-// When PasswordGracePeriod > 0, a per-terminal path keyed by the parent process
-// PID (typically the invoking shell) is returned so that each terminal session
-// authenticates independently. Otherwise the shared uid-keyed path is returned.
-func (c *BWClient) keyStorePath(uid string) string {
-	if c.PasswordGracePeriod > 0 {
-		ppid := fmt.Sprintf("%d", os.Getppid())
-		return sessionLocalKeyStorePath(uid, ppid)
-	}
-	return localKeyStorePath(uid)
-}
-
-// sessionLocalKeyStorePath returns a per-terminal local password store path.
-// Keyed by uid and the parent process PID (typically the invoking shell) so
-// that each terminal session has an independent authentication state.
-func sessionLocalKeyStorePath(uid, ppid string) string {
-	dir := "/tmp"
-	if fi, err := os.Stat("/dev/shm"); err == nil && fi.IsDir() {
-		dir = "/dev/shm"
-	}
-	return filepath.Join(dir, "renv-local-key-"+uid+"-"+ppid)
-}
-
-// loadLocalPasswordFromPath reads the local password stored at path.
-// When gracePeriod > 0 and the file is older than gracePeriod, the file is
-// deleted and ("", nil) is returned, forcing re-authentication on the next call.
-func loadLocalPasswordFromPath(path string, gracePeriod time.Duration) (string, error) {
-	fi, err := os.Stat(path)
-	if os.IsNotExist(err) {
-		return "", nil
-	}
-	if err != nil {
-		return "", fmt.Errorf("cache: stating local password store: %w", err)
-	}
-	if gracePeriod > 0 && time.Since(fi.ModTime()) > gracePeriod {
-		age := time.Since(fi.ModTime()).Round(time.Second)
-		slog.Debug("local password grace period expired; requiring re-authentication",
-			"path", path, "age", age, "grace_period", gracePeriod)
-		_ = os.Remove(path)
-		return "", nil
-	}
-	data, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
-		return "", nil
-	}
-	if err != nil {
-		return "", fmt.Errorf("cache: reading local password store: %w", err)
-	}
-	return string(data), nil
-}
-
-// saveLocalPasswordToPath writes the local password to path (chmod 0600).
-// The file's modification time is used as the "authenticated at" timestamp
-// for grace-period checks.
-func saveLocalPasswordToPath(path, password string) error {
-	if err := os.WriteFile(path, []byte(password), 0600); err != nil {
-		return fmt.Errorf("saving local password: %w", err)
-	}
-	slog.Debug("saved local password to store", "path", path)
 	return nil
 }
 
@@ -305,33 +203,9 @@ func localKeyStorePath(uid string) string {
 	return filepath.Join(dir, "renv-local-key-"+uid)
 }
 
-// SaveLocalPassword persists the local cache password to the shared store (chmod 0600).
-// The file lives in /dev/shm and is therefore RAM-backed and cleared on reboot.
-func SaveLocalPassword(uid, password string) error {
-	path := localKeyStorePath(uid)
-	if err := os.WriteFile(path, []byte(password), 0600); err != nil {
-		return fmt.Errorf("saving local password: %w", err)
-	}
-	slog.Debug("saved local password to shared store", "path", path)
-	return nil
-}
-
-// LoadStoredLocalPassword reads the shared local cache password.
-// Returns ("", nil) if the file does not exist.
-func LoadStoredLocalPassword(uid string) (string, error) {
-	path := localKeyStorePath(uid)
-	data, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
-		return "", nil
-	}
-	if err != nil {
-		return "", fmt.Errorf("reading local password store: %w", err)
-	}
-	return string(data), nil
-}
-
-// ClearStoredLocalPassword removes the shared local password file and any
-// per-terminal session key files for uid.
+// ClearStoredLocalPassword removes any local password files left by previous
+// versions of renv. The password is no longer written to disk, but legacy files
+// may still exist on systems that ran an older version.
 func ClearStoredLocalPassword(uid string) error {
 	dir := "/tmp"
 	if fi, err := os.Stat("/dev/shm"); err == nil && fi.IsDir() {

--- a/internal/secrets/bitwarden.go
+++ b/internal/secrets/bitwarden.go
@@ -80,6 +80,30 @@ func (c *BWClient) ensureLocalPassword() error {
 	return nil
 }
 
+// ReadLocalPassword returns the local cache encryption password from, in order:
+//  1. RENV_LOCAL_PASSWORD env var
+//  2. An interactive prompt on /dev/tty (no echo)
+//
+// Use this when you need the local password outside of a BWClient (e.g., when
+// fetching from Vault and then encrypting to the named kubeconfig store).
+func ReadLocalPassword() (string, error) {
+	if pw := os.Getenv("RENV_LOCAL_PASSWORD"); pw != "" {
+		return pw, nil
+	}
+	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		return "", fmt.Errorf("opening /dev/tty: %w", err)
+	}
+	defer tty.Close()
+	fmt.Fprintf(tty, "Local cache password: ")
+	pwBytes, err := term.ReadPassword(int(tty.Fd()))
+	if err != nil {
+		return "", fmt.Errorf("reading local cache password from tty: %w", err)
+	}
+	fmt.Fprintln(tty)
+	return string(pwBytes), nil
+}
+
 // AccountTag returns an 8-char fingerprint of the active BW account.
 // It is used as a cache key discriminator to namespace cache entries per account.
 // Result is memoised for the lifetime of the client and persisted to disk so

--- a/internal/secrets/bitwarden.go
+++ b/internal/secrets/bitwarden.go
@@ -62,6 +62,9 @@ func (c *BWClient) ensureLocalPassword() error {
 		return nil
 	}
 	if pw := os.Getenv("RENV_LOCAL_PASSWORD"); pw != "" {
+		if strings.TrimSpace(pw) == "" {
+			return fmt.Errorf("RENV_LOCAL_PASSWORD must not be empty or whitespace-only")
+		}
 		c.LocalPassword = pw
 		return nil
 	}
@@ -76,6 +79,9 @@ func (c *BWClient) ensureLocalPassword() error {
 		return fmt.Errorf("reading local cache password from tty: %w", err)
 	}
 	fmt.Fprintln(tty)
+	if strings.TrimSpace(string(pwBytes)) == "" {
+		return fmt.Errorf("local cache password must not be empty")
+	}
 	c.LocalPassword = string(pwBytes)
 	return nil
 }
@@ -86,8 +92,12 @@ func (c *BWClient) ensureLocalPassword() error {
 //
 // Use this when you need the local password outside of a BWClient (e.g., when
 // fetching from Vault and then encrypting to the named kubeconfig store).
+// Returns an error if the password is empty or whitespace-only.
 func ReadLocalPassword() (string, error) {
 	if pw := os.Getenv("RENV_LOCAL_PASSWORD"); pw != "" {
+		if strings.TrimSpace(pw) == "" {
+			return "", fmt.Errorf("RENV_LOCAL_PASSWORD must not be empty or whitespace-only")
+		}
 		return pw, nil
 	}
 	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
@@ -101,6 +111,9 @@ func ReadLocalPassword() (string, error) {
 		return "", fmt.Errorf("reading local cache password from tty: %w", err)
 	}
 	fmt.Fprintln(tty)
+	if strings.TrimSpace(string(pwBytes)) == "" {
+		return "", fmt.Errorf("local cache password must not be empty")
+	}
 	return string(pwBytes), nil
 }
 

--- a/internal/secrets/bitwarden_test.go
+++ b/internal/secrets/bitwarden_test.go
@@ -2,7 +2,6 @@ package secrets
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -168,123 +167,6 @@ func TestExtractFieldAllTypes(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("extractField(%q) = %q, want %q", tt.spec, got, tt.want)
 		}
-	}
-}
-
-// TestLoadLocalPasswordFromPath_GracePeriodExpired verifies that a stored
-// password file older than the grace period is removed and treated as a miss.
-func TestLoadLocalPasswordFromPath_GracePeriodExpired(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "renv-local-key-1000-9999")
-
-	if err := os.WriteFile(path, []byte("mypassword"), 0600); err != nil {
-		t.Fatalf("writing test file: %v", err)
-	}
-	// Back-date the file so it appears older than the grace period.
-	past := time.Now().Add(-2 * time.Minute)
-	if err := os.Chtimes(path, past, past); err != nil {
-		t.Fatalf("chtimes: %v", err)
-	}
-
-	pw, err := loadLocalPasswordFromPath(path, 1*time.Minute)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if pw != "" {
-		t.Errorf("expected empty password (expired), got %q", pw)
-	}
-	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
-		t.Error("expected expired key file to be removed")
-	}
-}
-
-// TestLoadLocalPasswordFromPath_WithinGracePeriod verifies that a recently
-// written password file is returned without re-prompting.
-func TestLoadLocalPasswordFromPath_WithinGracePeriod(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "renv-local-key-1000-9999")
-
-	const wantPW = "mypassword"
-	if err := os.WriteFile(path, []byte(wantPW), 0600); err != nil {
-		t.Fatalf("writing test file: %v", err)
-	}
-
-	pw, err := loadLocalPasswordFromPath(path, 5*time.Minute)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if pw != wantPW {
-		t.Errorf("got %q, want %q", pw, wantPW)
-	}
-}
-
-// TestLoadLocalPasswordFromPath_NoGracePeriod verifies that a zero grace period
-// means the file is always returned regardless of age.
-func TestLoadLocalPasswordFromPath_NoGracePeriod(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "renv-local-key-1000")
-
-	const wantPW = "sharedpassword"
-	if err := os.WriteFile(path, []byte(wantPW), 0600); err != nil {
-		t.Fatalf("writing test file: %v", err)
-	}
-	// Back-date well into the past — should not matter with gracePeriod==0.
-	past := time.Now().Add(-24 * time.Hour)
-	if err := os.Chtimes(path, past, past); err != nil {
-		t.Fatalf("chtimes: %v", err)
-	}
-
-	pw, err := loadLocalPasswordFromPath(path, 0)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if pw != wantPW {
-		t.Errorf("got %q, want %q", pw, wantPW)
-	}
-}
-
-// TestSessionLocalKeyStorePath verifies that separate PPIDs produce separate paths.
-func TestSessionLocalKeyStorePath(t *testing.T) {
-	uid := "1000"
-	path1 := sessionLocalKeyStorePath(uid, "1234")
-	path2 := sessionLocalKeyStorePath(uid, "5678")
-	if path1 == path2 {
-		t.Errorf("expected different paths for different PPIDs, got same: %s", path1)
-	}
-	// Both should contain the uid.
-	for _, p := range []string{path1, path2} {
-		if !filepath.IsAbs(p) {
-			t.Errorf("expected absolute path, got %q", p)
-		}
-	}
-}
-
-// TestKeyStorePath_GracePeriodZeroUsesShared verifies that with PasswordGracePeriod==0
-// the shared (uid-only) path is returned.
-func TestKeyStorePath_GracePeriodZeroUsesShared(t *testing.T) {
-	uid := fmt.Sprintf("%d", os.Getuid())
-	c := &BWClient{PasswordGracePeriod: 0}
-	got := c.keyStorePath(uid)
-	want := localKeyStorePath(uid)
-	if got != want {
-		t.Errorf("got %q, want shared path %q", got, want)
-	}
-}
-
-// TestKeyStorePath_GracePeriodSetUsesSessionPath verifies that with
-// PasswordGracePeriod > 0 a PPID-keyed path is returned (not the shared path).
-func TestKeyStorePath_GracePeriodSetUsesSessionPath(t *testing.T) {
-	uid := fmt.Sprintf("%d", os.Getuid())
-	c := &BWClient{PasswordGracePeriod: time.Minute}
-	got := c.keyStorePath(uid)
-	shared := localKeyStorePath(uid)
-	if got == shared {
-		t.Errorf("expected per-terminal path, got shared path %q", got)
-	}
-	ppid := fmt.Sprintf("%d", os.Getppid())
-	want := sessionLocalKeyStorePath(uid, ppid)
-	if got != want {
-		t.Errorf("got %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
- [x] Fix vault:// URI parsing in `kctx load` to handle `#field` fragments (cmd/kctx/main.go) — checks for `#` first, parses fully with `ParseVaultRef` if present, defaults field to "kubeconfig" if absent
- [x] Fix vault:// URI parsing in `fetchKubeconfig` with same approach (cmd/kctx/main.go)
- [x] Replace `ui.Item(w, "•", n)` loop with sorted `ui.List(w, names)` in status command (cmd/kctx/main.go)
- [x] Make `NamedStore.Put` use atomic temp file + rename write (internal/kubeconfig/store.go)
- [x] Fix `TestNamedStore_Get_Expired` to use `os.Chtimes` instead of `time.Sleep` (store_test.go)
- [x] Fix `TestNamedStore_List_ExcludesExpired` to use `os.Chtimes` instead of `time.Sleep` (store_test.go)
- [x] Reject empty/whitespace-only password in `ReadLocalPassword` and `ensureLocalPassword` (internal/secrets/bitwarden.go)
- [x] Add deprecated no-op `--isolated` and `--password-grace-period` flags to renv for backwards compatibility (cmd/renv/main.go)