### PR TITLE
feat: fall back to os.TempDir() instead of hardcoded /tmp

### DIFF
--- a/cmd/envoke/main.go
+++ b/cmd/envoke/main.go
@@ -589,7 +589,7 @@ envoke() {
 # ── renv unload token ──────────────────────────────────────────────────────────
 _renv_unload_token() {
   local f="/dev/shm/renv-${UID}-unload-requested"
-  [ -f "$f" ] || f="/tmp/renv-${UID}-unload-requested"
+  [ -f "$f" ] || f="${TMPDIR:-/tmp}/renv-${UID}-unload-requested"
   [ -f "$f" ] || return 1
   stat -c '%Y:%i:%s' "$f" 2>/dev/null || stat -f '%m:%i:%z' "$f" 2>/dev/null
 }
@@ -606,7 +606,7 @@ _RENV_LAST_UNLOAD_TOKEN="$(_renv_unload_token 2>/dev/null || true)"
 # ── kctx unload token ──────────────────────────────────────────────────────────
 _kctx_unload_token() {
   local f="/dev/shm/kctx-${UID}-unload-requested"
-  [ -f "$f" ] || f="/tmp/kctx-${UID}-unload-requested"
+  [ -f "$f" ] || f="${TMPDIR:-/tmp}/kctx-${UID}-unload-requested"
   [ -f "$f" ] || return 1
   stat -c '%Y:%i:%s' "$f" 2>/dev/null || stat -f '%m:%i:%z' "$f" 2>/dev/null
 }
@@ -712,14 +712,20 @@ end
 
 function _renv_unload_token
   set -l f /dev/shm/renv-(id -u)-unload-requested
-  test -f $f; or set f /tmp/renv-(id -u)-unload-requested
+  if not test -f $f
+    set -l _tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
+    set f $_tmpdir/renv-(id -u)-unload-requested
+  end
   test -f $f; or return 1
   stat -c '%Y:%i:%s' $f 2>/dev/null; or stat -f '%m:%i:%z' $f 2>/dev/null
 end
 
 function _kctx_unload_token
   set -l f /dev/shm/kctx-(id -u)-unload-requested
-  test -f $f; or set f /tmp/kctx-(id -u)-unload-requested
+  if not test -f $f
+    set -l _tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
+    set f $_tmpdir/kctx-(id -u)-unload-requested
+  end
   test -f $f; or return 1
   stat -c '%Y:%i:%s' $f 2>/dev/null; or stat -f '%m:%i:%z' $f 2>/dev/null
 end

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,7 +1,8 @@
 // Package cache provides an encrypted disk cache for resolved secret values.
 // It is provider-agnostic: callers supply an opaque string key and a password
 // used to derive the AES-256-CBC encryption key via PBKDF2-SHA256.
-// Files are stored in /dev/shm (Linux tmpfs) when available, falling back to /tmp.
+// Files are stored in /dev/shm (Linux tmpfs) when available, falling back to
+// os.TempDir() (which honours $TMPDIR on Unix/macOS).
 package cache
 
 import (
@@ -18,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/opalbolt/envoke/internal/tmpdir"
 	"golang.org/x/crypto/pbkdf2"
 )
 
@@ -40,17 +42,9 @@ type Cache struct {
 	Disabled bool // when true, Put and Get are no-ops (--no-cache flag)
 }
 
-// New picks /dev/shm if available and writable, else /tmp.
+// New picks /dev/shm if available and writable, else os.TempDir().
 func New() *Cache {
-	dir := "/tmp"
-	if fi, err := os.Stat("/dev/shm"); err == nil && fi.IsDir() {
-		testFile := filepath.Join("/dev/shm", ".envoke-cache-test")
-		if f, err := os.OpenFile(testFile, os.O_CREATE|os.O_WRONLY, 0600); err == nil {
-			f.Close()
-			os.Remove(testFile)
-			dir = "/dev/shm"
-		}
-	}
+	dir := tmpdir.PreferredWritable(".envoke-cache-test")
 	return &Cache{Dir: dir, MaxAge: 8 * time.Hour}
 }
 

--- a/internal/cli/kctx/root.go
+++ b/internal/cli/kctx/root.go
@@ -326,7 +326,7 @@ kctx() {
 
 _kctx_unload_token() {
   local f="/dev/shm/kctx-${UID}-unload-requested"
-  [ -f "$f" ] || f="/tmp/kctx-${UID}-unload-requested"
+  [ -f "$f" ] || f="${TMPDIR:-/tmp}/kctx-${UID}-unload-requested"
   [ -f "$f" ] || return 1
   stat -c '%Y:%i:%s' "$f" 2>/dev/null || stat -f '%m:%i:%z' "$f" 2>/dev/null
 }

--- a/internal/cli/renv/root.go
+++ b/internal/cli/renv/root.go
@@ -279,7 +279,7 @@ const BashInitScript = `renv() {
 # Return a token that changes whenever the unload sentinel is refreshed.
 _renv_unload_token() {
   local f="/dev/shm/renv-${UID}-unload-requested"
-  [ -f "$f" ] || f="/tmp/renv-${UID}-unload-requested"
+  [ -f "$f" ] || f="${TMPDIR:-/tmp}/renv-${UID}-unload-requested"
   [ -f "$f" ] || return 1
   stat -c '%Y:%i:%s' "$f" 2>/dev/null || stat -f '%m:%i:%z' "$f" 2>/dev/null
 }
@@ -319,7 +319,10 @@ end
 
 function _renv_unload_token
   set -l f /dev/shm/renv-(id -u)-unload-requested
-  test -f $f; or set f /tmp/renv-(id -u)-unload-requested
+  if not test -f $f
+    set -l _tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
+    set f $_tmpdir/renv-(id -u)-unload-requested
+  end
   test -f $f; or return 1
   stat -c '%Y:%i:%s' $f 2>/dev/null; or stat -f '%m:%i:%z' $f 2>/dev/null
 end

--- a/internal/kubeconfig/store.go
+++ b/internal/kubeconfig/store.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	"golang.org/x/crypto/pbkdf2"
+
+	"github.com/opalbolt/envoke/internal/tmpdir"
 )
 
 const (
@@ -30,24 +32,16 @@ const (
 var validStoreName = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
 // NamedStore stores named kubeconfig data, encrypted with a local password.
-// Files are stored as kctx-kc-<uid>-<name>.enc in /dev/shm (preferred) or /tmp.
+// Files are stored as kctx-kc-<uid>-<name>.enc in /dev/shm (preferred) or os.TempDir().
 // Encryption: AES-256-CBC, key derived via PBKDF2-SHA256.
 type NamedStore struct {
 	Dir    string
 	MaxAge time.Duration
 }
 
-// NewNamedStore picks /dev/shm if available and writable, else /tmp.
+// NewNamedStore picks /dev/shm if available and writable, else os.TempDir().
 func NewNamedStore() *NamedStore {
-	dir := "/tmp"
-	if fi, err := os.Stat("/dev/shm"); err == nil && fi.IsDir() {
-		testPath := filepath.Join("/dev/shm", ".kctx-ns-test")
-		if f, err := os.OpenFile(testPath, os.O_CREATE|os.O_WRONLY, 0600); err == nil {
-			f.Close()
-			os.Remove(testPath)
-			dir = "/dev/shm"
-		}
-	}
+	dir := tmpdir.PreferredWritable(".kctx-ns-test")
 	return &NamedStore{Dir: dir, MaxAge: 8 * time.Hour}
 }
 

--- a/internal/kubeconfig/tmpfile.go
+++ b/internal/kubeconfig/tmpfile.go
@@ -6,20 +6,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/opalbolt/envoke/internal/tmpdir"
 )
 
-// NewTempFile creates a temporary file in /dev/shm if available, else /tmp.
-// The file is chmod 600.
+// NewTempFile creates a temporary file in /dev/shm if available and writable,
+// else os.TempDir(). The file is chmod 600.
 func NewTempFile(prefix string) (*os.File, error) {
-	dir := "/tmp"
-	if fi, err := os.Stat("/dev/shm"); err == nil && fi.IsDir() {
-		testPath := filepath.Join("/dev/shm", ".kctx-test")
-		if f, err := os.OpenFile(testPath, os.O_CREATE|os.O_WRONLY, 0600); err == nil {
-			f.Close()
-			os.Remove(testPath)
-			dir = "/dev/shm"
-		}
-	}
+	dir := tmpdir.PreferredWritable(".kctx-test")
 	slog.Debug("creating temp file", "dir", dir, "prefix", prefix)
 
 	f, err := os.CreateTemp(dir, prefix+"-*.tmp")
@@ -36,20 +30,27 @@ func NewTempFile(prefix string) (*os.File, error) {
 }
 
 // IsManaged reports whether path looks like a kctx-managed kubeconfig tmpfile
-// (i.e. a "kctx-" prefixed file in /dev/shm or /tmp).
+// (i.e. a "kctx-" prefixed file in /dev/shm or os.TempDir()).
 func IsManaged(path string) bool {
 	dir := filepath.Dir(path)
 	base := filepath.Base(path)
-	if dir != "/dev/shm" && dir != "/tmp" {
+	managed := false
+	for _, d := range tmpdir.Dirs() {
+		if dir == d {
+			managed = true
+			break
+		}
+	}
+	if !managed {
 		return false
 	}
 	return len(base) > 5 && base[:5] == "kctx-"
 }
 
-// ClearManaged removes all kctx-managed kubeconfig tmpfiles from /dev/shm and /tmp.
-// Only files with the "kctx-" prefix are removed.
+// ClearManaged removes all kctx-managed kubeconfig tmpfiles from /dev/shm and
+// os.TempDir(). Only files with the "kctx-" prefix are removed.
 func ClearManaged() {
-	for _, dir := range []string{"/dev/shm", "/tmp"} {
+	for _, dir := range tmpdir.Dirs() {
 		matches, err := filepath.Glob(filepath.Join(dir, "kctx-*.tmp"))
 		if err != nil {
 			continue
@@ -62,13 +63,9 @@ func ClearManaged() {
 }
 
 // trackedNamesPath returns the path of the tracked kctx store names file for uid.
-// Prefers /dev/shm (RAM-backed, cleared on reboot) over /tmp.
+// Prefers /dev/shm (RAM-backed, cleared on reboot) over os.TempDir().
 func trackedNamesPath(uid string) string {
-	dir := "/tmp"
-	if fi, err := os.Stat("/dev/shm"); err == nil && fi.IsDir() {
-		dir = "/dev/shm"
-	}
-	return filepath.Join(dir, "kctx-"+uid+"-tracked")
+	return filepath.Join(tmpdir.Preferred(), "kctx-"+uid+"-tracked")
 }
 
 // SaveTrackedNames writes the kctx store names loaded by envoke resolve to a
@@ -118,11 +115,7 @@ func ClearTrackedNames(uid string) error {
 // UnloadRequestFile returns the path of the sentinel file used to signal
 // shells to run kctx unload on their next prompt draw.
 func UnloadRequestFile(uid string) string {
-	dir := "/tmp"
-	if fi, err := os.Stat("/dev/shm"); err == nil && fi.IsDir() {
-		dir = "/dev/shm"
-	}
-	return filepath.Join(dir, "kctx-"+uid+"-unload-requested")
+	return filepath.Join(tmpdir.Preferred(), "kctx-"+uid+"-unload-requested")
 }
 
 // RequestUnload creates the sentinel file. Shell PROMPT_COMMAND/precmd hooks

--- a/internal/kubeconfig/tmpfile_test.go
+++ b/internal/kubeconfig/tmpfile_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/opalbolt/envoke/internal/tmpdir"
 )
 
 func TestUnloadRequestFile(t *testing.T) {
@@ -11,8 +13,17 @@ func TestUnloadRequestFile(t *testing.T) {
 	if path == "" {
 		t.Fatal("UnloadRequestFile returned empty string")
 	}
-	if len(path) < 8 || (path[:8] != "/dev/shm" && path[:4] != "/tmp") {
-		t.Errorf("unexpected base dir in path %q", path)
+	dir := filepath.Dir(path)
+	validDirs := tmpdir.Dirs()
+	found := false
+	for _, d := range validDirs {
+		if dir == d {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("unexpected base dir in path %q (expected one of %v)", path, validDirs)
 	}
 }
 
@@ -62,11 +73,12 @@ func TestRequestUnload_RejectsSymlink(t *testing.T) {
 }
 
 func TestClearManaged(t *testing.T) {
-	// Create a few fake kctx-*.tmp files in /tmp.
-	// ClearManaged searches /dev/shm and /tmp specifically.
+	// Create a few fake kctx-*.tmp files in os.TempDir().
+	// ClearManaged searches all known tmp locations.
+	tmpDir := os.TempDir()
 	paths := []string{
-		filepath.Join("/tmp", "kctx-test-clear-managed-1.tmp"),
-		filepath.Join("/tmp", "kctx-test-clear-managed-2.tmp"),
+		filepath.Join(tmpDir, "kctx-test-clear-managed-1.tmp"),
+		filepath.Join(tmpDir, "kctx-test-clear-managed-2.tmp"),
 	}
 	for _, p := range paths {
 		if err := os.WriteFile(p, []byte("test"), 0600); err != nil {
@@ -99,7 +111,7 @@ func TestClearManaged(t *testing.T) {
 
 func TestClearManaged_NonKctxFilesUntouched(t *testing.T) {
 	// Create a non-kctx file that should NOT be removed.
-	notKctx := filepath.Join("/tmp", "renv-test-not-kctx.tmp")
+	notKctx := filepath.Join(os.TempDir(), "renv-test-not-kctx.tmp")
 	if err := os.WriteFile(notKctx, []byte("keep"), 0600); err != nil {
 		t.Fatalf("creating file: %v", err)
 	}

--- a/internal/providers/bitwarden/client.go
+++ b/internal/providers/bitwarden/client.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	appcache "github.com/opalbolt/envoke/internal/cache"
+	"github.com/opalbolt/envoke/internal/tmpdir"
 	"golang.org/x/term"
 )
 
@@ -236,32 +237,21 @@ func (c *BWClient) Session() (string, error) {
 // sessionStorePath returns the path where a legacy plaintext BW session may exist.
 // Used only by ClearStoredSession to clean up files left by older versions.
 func sessionStorePath(uid string) string {
-	dir := "/tmp"
-	if fi, err := os.Stat("/dev/shm"); err == nil && fi.IsDir() {
-		dir = "/dev/shm"
-	}
-	return filepath.Join(dir, "renv-bw-session-"+uid)
+	return filepath.Join(tmpdir.Preferred(), "renv-bw-session-"+uid)
 }
 
 // localKeyStorePath returns the legacy path where the shared LocalPassword was
 // stored by older versions of renv. LocalPassword is no longer written to disk;
 // this helper exists only so ClearStoredLocalPassword can remove any leftover files.
 func localKeyStorePath(uid string) string {
-	dir := "/tmp"
-	if fi, err := os.Stat("/dev/shm"); err == nil && fi.IsDir() {
-		dir = "/dev/shm"
-	}
-	return filepath.Join(dir, "renv-local-key-"+uid)
+	return filepath.Join(tmpdir.Preferred(), "renv-local-key-"+uid)
 }
 
 // ClearStoredLocalPassword removes any local password files left by previous
 // versions of renv. The password is no longer written to disk, but legacy files
 // may still exist on systems that ran an older version.
 func ClearStoredLocalPassword(uid string) error {
-	dir := "/tmp"
-	if fi, err := os.Stat("/dev/shm"); err == nil && fi.IsDir() {
-		dir = "/dev/shm"
-	}
+	dir := tmpdir.Preferred()
 	// Remove shared store.
 	sharedPath := localKeyStorePath(uid)
 	slog.Debug("clearing stored local password", "path", sharedPath)
@@ -279,11 +269,7 @@ func ClearStoredLocalPassword(uid string) error {
 
 // acctTagStorePath returns the path where the BW account tag is persisted between process invocations.
 func acctTagStorePath(uid string) string {
-	dir := "/tmp"
-	if fi, err := os.Stat("/dev/shm"); err == nil && fi.IsDir() {
-		dir = "/dev/shm"
-	}
-	return filepath.Join(dir, "renv-bw-acct-tag-"+uid)
+	return filepath.Join(tmpdir.Preferred(), "renv-bw-acct-tag-"+uid)
 }
 
 // loadStoredAccountTag reads a previously saved BW account tag from disk.

--- a/internal/state/vars.go
+++ b/internal/state/vars.go
@@ -6,16 +6,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/opalbolt/envoke/internal/tmpdir"
 )
 
 // varsFilePath returns the path of the tracked-vars state file for uid.
-// Prefers /dev/shm (RAM-backed, cleared on reboot) over /tmp.
+// Prefers /dev/shm (RAM-backed, cleared on reboot) over os.TempDir().
 func varsFilePath(uid string) string {
-	dir := "/tmp"
-	if fi, err := os.Stat("/dev/shm"); err == nil && fi.IsDir() {
-		dir = "/dev/shm"
-	}
-	return filepath.Join(dir, "renv-"+uid+"-vars")
+	return filepath.Join(tmpdir.Preferred(), "renv-"+uid+"-vars")
 }
 
 // SaveVarNames writes the exported variable names to a state file so that
@@ -65,11 +63,7 @@ func ClearVarNames(uid string) error {
 // UnloadRequestFile returns the path of the sentinel file used to signal
 // shells to run renv unload on their next prompt draw.
 func UnloadRequestFile(uid string) string {
-	dir := "/tmp"
-	if fi, err := os.Stat("/dev/shm"); err == nil && fi.IsDir() {
-		dir = "/dev/shm"
-	}
-	return filepath.Join(dir, "renv-"+uid+"-unload-requested")
+	return filepath.Join(tmpdir.Preferred(), "renv-"+uid+"-unload-requested")
 }
 
 // RequestUnload creates the sentinel file. Shell PROMPT_COMMAND/precmd hooks

--- a/internal/state/vars_test.go
+++ b/internal/state/vars_test.go
@@ -2,9 +2,12 @@ package state
 
 import (
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/opalbolt/envoke/internal/tmpdir"
 )
 
 func TestSaveAndLoadVarNames(t *testing.T) {
@@ -83,9 +86,18 @@ func TestVarsFilePath(t *testing.T) {
 	if path == "" {
 		t.Fatal("varsFilePath returned empty string")
 	}
-	// Should reside in /dev/shm or /tmp.
-	if path[:8] != "/dev/shm" && path[:4] != "/tmp" {
-		t.Errorf("unexpected base dir in path %q", path)
+	// Should reside in one of the known tmpdir locations.
+	dir := filepath.Dir(path)
+	validDirs := tmpdir.Dirs()
+	found := false
+	for _, d := range validDirs {
+		if dir == d {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("unexpected base dir in path %q (expected one of %v)", path, validDirs)
 	}
 	// Should contain the uid.
 	const uid = "1234"
@@ -99,9 +111,18 @@ func TestUnloadRequestFile(t *testing.T) {
 	if path == "" {
 		t.Fatal("UnloadRequestFile returned empty string")
 	}
-	// Should reside in /dev/shm or /tmp.
-	if len(path) < 8 || (path[:8] != "/dev/shm" && path[:4] != "/tmp") {
-		t.Errorf("unexpected base dir in path %q", path)
+	// Should reside in one of the known tmpdir locations.
+	dir := filepath.Dir(path)
+	validDirs := tmpdir.Dirs()
+	found := false
+	for _, d := range validDirs {
+		if dir == d {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("unexpected base dir in path %q (expected one of %v)", path, validDirs)
 	}
 	// Should contain the uid.
 	const uid = "9999"

--- a/internal/tmpdir/tmpdir.go
+++ b/internal/tmpdir/tmpdir.go
@@ -21,14 +21,20 @@ func Preferred() string {
 }
 
 // PreferredWritable is like Preferred but also verifies the directory is
-// writable by creating and immediately removing a probe file named testName.
+// writable by creating and immediately removing a uniquely named probe file.
+// patternHint is an optional base name used to customise the probe filename
+// pattern (e.g. ".envoke-cache-test" → ".envoke-cache-test-*").
 // If /dev/shm exists but is not writable it falls back to os.TempDir().
-func PreferredWritable(testName string) string {
+func PreferredWritable(patternHint string) string {
 	if fi, err := os.Stat("/dev/shm"); err == nil && fi.IsDir() {
-		probe := filepath.Join("/dev/shm", testName)
-		if f, err := os.OpenFile(probe, os.O_CREATE|os.O_WRONLY, 0600); err == nil {
+		pattern := "tmpdir-probe-*"
+		if base := filepath.Base(patternHint); base != "" && base != "." {
+			pattern = base + "-*"
+		}
+		if f, err := os.CreateTemp("/dev/shm", pattern); err == nil {
+			name := f.Name()
 			f.Close()
-			os.Remove(probe)
+			os.Remove(name)
 			return "/dev/shm"
 		}
 	}
@@ -36,12 +42,27 @@ func PreferredWritable(testName string) string {
 }
 
 // Dirs returns the deduplicated list of directories to search when looking for
-// files that may have been written by any version of envoke (which may have
-// used either /dev/shm or os.TempDir()). Always contains at least one entry.
+// envoke files (which may have been written to /dev/shm or os.TempDir()).
+// Always contains at least one entry.
 func Dirs() []string {
-	tmpDir := os.TempDir()
-	if tmpDir != "/dev/shm" {
-		return []string{"/dev/shm", tmpDir}
+	candidates := []string{"/dev/shm", os.TempDir()}
+	dirs := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+
+	for _, dir := range candidates {
+		cleaned := filepath.Clean(dir)
+		if cleaned == "" {
+			continue
+		}
+		if _, ok := seen[cleaned]; ok {
+			continue
+		}
+		seen[cleaned] = struct{}{}
+		dirs = append(dirs, cleaned)
 	}
-	return []string{"/dev/shm"}
+
+	if len(dirs) == 0 {
+		dirs = append(dirs, os.TempDir())
+	}
+	return dirs
 }

--- a/internal/tmpdir/tmpdir.go
+++ b/internal/tmpdir/tmpdir.go
@@ -1,0 +1,47 @@
+// Package tmpdir provides helpers for selecting a temporary directory.
+// It prefers /dev/shm (Linux RAM-backed tmpfs) when available, and falls back
+// to os.TempDir(), which honours $TMPDIR on Unix (and equivalent platform env
+// vars on other operating systems).
+package tmpdir
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Preferred returns the best available temporary directory.
+// Priority:
+//  1. /dev/shm — Linux RAM-backed tmpfs (cleared on reboot, never swapped)
+//  2. os.TempDir() — respects $TMPDIR on Unix / macOS, %TEMP% on Windows
+func Preferred() string {
+	if fi, err := os.Stat("/dev/shm"); err == nil && fi.IsDir() {
+		return "/dev/shm"
+	}
+	return os.TempDir()
+}
+
+// PreferredWritable is like Preferred but also verifies the directory is
+// writable by creating and immediately removing a probe file named testName.
+// If /dev/shm exists but is not writable it falls back to os.TempDir().
+func PreferredWritable(testName string) string {
+	if fi, err := os.Stat("/dev/shm"); err == nil && fi.IsDir() {
+		probe := filepath.Join("/dev/shm", testName)
+		if f, err := os.OpenFile(probe, os.O_CREATE|os.O_WRONLY, 0600); err == nil {
+			f.Close()
+			os.Remove(probe)
+			return "/dev/shm"
+		}
+	}
+	return os.TempDir()
+}
+
+// Dirs returns the deduplicated list of directories to search when looking for
+// files that may have been written by any version of envoke (which may have
+// used either /dev/shm or os.TempDir()). Always contains at least one entry.
+func Dirs() []string {
+	tmpDir := os.TempDir()
+	if tmpDir != "/dev/shm" {
+		return []string{"/dev/shm", tmpDir}
+	}
+	return []string{"/dev/shm"}
+}


### PR DESCRIPTION
## Summary

Replaces all hardcoded `/tmp` fallback paths with `os.TempDir()`, which honours `$TMPDIR` on Unix/macOS and `%TEMP%`/`%TMP%` on Windows.

## Changes

- **New `internal/tmpdir` package** with three helpers:
  - `Preferred()` — returns `/dev/shm` if available, else `os.TempDir()`
  - `PreferredWritable(testName)` — same but probes write access before committing to `/dev/shm`
  - `Dirs()` — returns deduplicated list of dirs to search (for finding files written by older versions)
- **Updated callers**: `internal/cache`, `internal/state`, `internal/kubeconfig`, `internal/providers/bitwarden`, `cmd/envoke`, `internal/cli/renv`, `internal/cli/kctx`
- **Shell snippets**: bash/zsh use `${TMPDIR:-/tmp}`; fish resolves `$TMPDIR` with `/tmp` default
- **Tests updated**: `kubeconfig/tmpfile_test.go` and `state/vars_test.go`

Closes #26