### PR TITLE
fix(flake): update vendorHash for current dependency tree

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
           pname = "envoke";
           version = releaseVersion;
           src = ./.;
-          vendorHash = "sha256-U5ObZjq8TzaBKP8AbmoX/3Ylt5feuNMXM7JfGXF2NyA=";
+          vendorHash = "sha256-qhStGkBdR1ClZp3Wb0pI9uVZWxejFrvT1G9ujPw8Ubg=";
           subPackages = [ "cmd/envoke" ];
           ldflags = [
             "-s" "-w"


### PR DESCRIPTION
## Summary

Fixes #47

The `vendorHash` in `flake.nix` was stale after dependency updates, causing `nix build` to fail with a hash mismatch:

```
specified: sha256-U5ObZjq8TzaBKP8AbmoX/3Ylt5feuNMXM7JfGXF2NyA=
   got:    sha256-qhStGkBdR1ClZp3Wb0pI9uVZWxejFrvT1G9ujPw8Ubg=
```

## Changes

- Updated `vendorHash` in `flake.nix` to `sha256-qhStGkBdR1ClZp3Wb0pI9uVZWxejFrvT1G9ujPw8Ubg=`

## Verification

`nix build --no-link` succeeds without hash mismatch errors.