### PR TITLE
refactor(shell-init): simplify to minimal KISS snippet (#55)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,5 @@ go.work.sum
 
 # Local tooling
 .blip/
+.gocache/
 settings.local.json

--- a/cmd/envoke/main.go
+++ b/cmd/envoke/main.go
@@ -766,13 +766,9 @@ envoke_eval() {
   eval "$(printf '%s\n' "$_out" | grep -v '^trap ')"
 }
 _envoke_unload_token() {
-  local f1="{{SECUREDIR}}/renv-${UID}-unload-requested"
-  local f2="{{SECUREDIR}}/kctx-${UID}-unload-requested"
-  local t1="" t2=""
-  [ -f "$f1" ] && t1="$(stat -c '%Y:%i:%s' "$f1" 2>/dev/null || stat -f '%m:%i:%z' "$f1" 2>/dev/null || true)"
-  [ -f "$f2" ] && t2="$(stat -c '%Y:%i:%s' "$f2" 2>/dev/null || stat -f '%m:%i:%z' "$f2" 2>/dev/null || true)"
-  [ -z "$t1" ] && [ -z "$t2" ] && return 1
-  printf '%s|%s\n' "$t1" "$t2"
+  local f="{{SECUREDIR}}/envoke-${UID}-unload-requested"
+  [ -f "$f" ] || return 1
+  stat -c '%Y:%i:%s' "$f" 2>/dev/null || stat -f '%m:%i:%z' "$f" 2>/dev/null || true
 }
 _envoke_check_unload() {
   local t; t="$(_envoke_unload_token)" || return 0
@@ -806,14 +802,9 @@ function envoke_eval
   printf '%s\n' $_out | grep -v '^trap ' | source
 end
 function _envoke_unload_token
-  set -l uid (id -u)
-  set -l f1 {{SECUREDIR}}/renv-$uid-unload-requested
-  set -l f2 {{SECUREDIR}}/kctx-$uid-unload-requested
-  set -l t1 ""; set -l t2 ""
-  test -f $f1; and set t1 (stat -c '%Y:%i:%s' $f1 2>/dev/null; or stat -f '%m:%i:%z' $f1 2>/dev/null; or echo "")
-  test -f $f2; and set t2 (stat -c '%Y:%i:%s' $f2 2>/dev/null; or stat -f '%m:%i:%z' $f2 2>/dev/null; or echo "")
-  test -z "$t1" -a -z "$t2"; and return 1
-  printf '%s|%s\n' $t1 $t2
+  set -l f {{SECUREDIR}}/envoke-(id -u)-unload-requested
+  test -f $f; or return 1
+  stat -c '%Y:%i:%s' $f 2>/dev/null; or stat -f '%m:%i:%z' $f 2>/dev/null; or true
 end
 function _envoke_check_unload --on-event fish_prompt
   set -l t (_envoke_unload_token); or return

--- a/cmd/envoke/main.go
+++ b/cmd/envoke/main.go
@@ -814,7 +814,7 @@ function _envoke_check_unload --on-event fish_prompt
 end
 function _envoke_cleanup --on-event fish_exit
   if test -n "$_ENVOKE_WATCH_PID"
-    kill -0 $_ENVOKE_WATCH_PID 2>/dev/null; and kill $_ENVOKE_WATCH_PID 2>/dev/null; or true
+    kill -0 "$_ENVOKE_WATCH_PID" 2>/dev/null; and kill "$_ENVOKE_WATCH_PID" 2>/dev/null; or true
     set -e _ENVOKE_WATCH_PID
   end
   command envoke unload 2>/dev/null | grep -v '^trap ' | source 2>/dev/null; or true

--- a/cmd/envoke/main.go
+++ b/cmd/envoke/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/opalbolt/envoke/internal/logger"
 	"github.com/opalbolt/envoke/internal/providers"
 	bw "github.com/opalbolt/envoke/internal/providers/bitwarden"
+	"github.com/opalbolt/envoke/internal/securedir"
 	"github.com/opalbolt/envoke/internal/state"
 	"github.com/opalbolt/envoke/internal/ui"
 	"github.com/opalbolt/envoke/internal/version"
@@ -727,14 +728,16 @@ After that:
 					"  envoke shell-init --shell fish | source\n\n" +
 					"Use --force to override this check.")
 			}
+			secureDir := securedir.Dir()
+			var script string
 			switch shell {
 			case "fish":
-				_, err := io.WriteString(cmd.OutOrStdout(), fishCombinedInitScript)
-				return err
+				script = strings.ReplaceAll(fishCombinedInitScript, "{{SECUREDIR}}", secureDir)
 			default:
-				_, err := io.WriteString(cmd.OutOrStdout(), bashCombinedInitScript)
-				return err
+				script = strings.ReplaceAll(bashCombinedInitScript, "{{SECUREDIR}}", secureDir)
 			}
+			_, err := io.WriteString(cmd.OutOrStdout(), script)
+			return err
 		},
 	}
 	cmd.Flags().StringVar(&shell, "shell", "bash", "Shell type: bash, zsh, fish")
@@ -746,166 +749,69 @@ After that:
 // Defines an envoke() shell function that auto-evals resolve, unload, and switch output,
 // starts a single background watcher, and installs a combined EXIT trap.
 const bashCombinedInitScript = `
-# envoke shell integration — add to ~/.bashrc or ~/.zshrc:
-#   eval "$(envoke shell-init)"
-
 envoke() {
   case "$1" in
-    resolve)
-      # Help/version: print directly, do not eval — scan all args.
-      local _a
-      for _a in "${@:2}"; do
-        case "$_a" in --help|-h|--version) command envoke resolve "${@:2}"; return ;; esac
-      done
-      local _envoke_out _envoke_exit
-      _envoke_out="$(command envoke resolve "${@:2}")"
-      _envoke_exit=$?
-      [ "$_envoke_exit" -ne 0 ] && return "$_envoke_exit"
-      # Auto-eval so secrets and kubeconfigs are loaded into the current shell.
-      # Strip the standalone EXIT trap — the shell-init trap below covers cleanup.
-      eval "$(printf '%s\n' "$_envoke_out" | grep -v '^trap ')"
-      ;;
-    unload)
-      # Help/version: print directly, do not eval — scan all args.
-      local _a
-      for _a in "${@:2}"; do
-        case "$_a" in --help|-h|--version) command envoke unload "${@:2}"; return ;; esac
-      done
-      local _envoke_out _envoke_exit
-      _envoke_out="$(command envoke unload)"
-      _envoke_exit=$?
-      [ "$_envoke_exit" -ne 0 ] && return "$_envoke_exit"
-      eval "$(printf '%s\n' "$_envoke_out" | grep -v '^trap ')"
-      ;;
-    switch)
-      # IMPORTANT: never call 'trap' inside this function. In zsh, a trap set
-      # inside a function fires when the function returns, not when the shell exits.
-      # Kubeconfig cleanup is handled by the shell-init EXIT trap below.
-      local _envoke_out _envoke_exit
-      _envoke_out="$(command envoke switch "${@:2}")"
-      _envoke_exit=$?
-      [ "$_envoke_exit" -ne 0 ] && return "$_envoke_exit"
-      eval "$(printf '%s\n' "$_envoke_out" | grep -v '^trap ')"
-      _ENVOKE_LAST_UNLOAD_TOKEN="$(_envoke_unload_token 2>/dev/null || true)"
-      ;;
-    *)
-      command envoke "$@"
-      ;;
+    resolve) envoke_eval resolve "${@:2}" ;;
+    unload) envoke_eval unload ;;
+    switch) envoke_eval switch "${@:2}"; _ENVOKE_LAST_UNLOAD_TOKEN="$(_envoke_unload_token 2>/dev/null || true)" ;;
+    *) command envoke "$@" ;;
   esac
 }
-
-# ── unload token ───────────────────────────────────────────────────────────────
-# Returns a combined token for both renv and kctx sentinel files.
-# Returns 1 if neither file exists (no pending unload signal).
-_envoke_unload_token() {
-  local f1="/dev/shm/renv-${UID}-unload-requested"
-  [ -f "$f1" ] || f1="/tmp/renv-${UID}-unload-requested"
-  local f2="/dev/shm/kctx-${UID}-unload-requested"
-  [ -f "$f2" ] || f2="/tmp/kctx-${UID}-unload-requested"
-  local t1="" t2=""
-  [ -f "$f1" ] && t1="$(stat -c '%Y:%i:%s' "$f1" 2>/dev/null || stat -f '%m:%i:%z' "$f1" 2>/dev/null || true)"
-  [ -f "$f2" ] && t2="$(stat -c '%Y:%i:%s' "$f2" 2>/dev/null || stat -f '%m:%i:%z' "$f2" 2>/dev/null || true)"
-  [ -z "$t1" ] && [ -z "$t2" ] && return 1
-  printf '%s|%s\n' "$t1" "$t2"
+envoke_eval() {
+  local _cmd="$1" _out _exit
+  shift
+  for _arg in "$@"; do case "$_arg" in --help|-h|--version) command envoke "$_cmd" "$@"; return ;; esac; done
+  _out="$(command envoke "$_cmd" "$@")" _exit=$?
+  [ $_exit -ne 0 ] && return $_exit
+  eval "$(printf '%s\n' "$_out" | grep -v '^trap ')"
 }
-
+_envoke_unload_token() {
+  local f="{{SECUREDIR}}/envoke-${UID}-unload-requested"
+  [ -f "$f" ] && stat -c '%Y:%i:%s' "$f" 2>/dev/null || stat -f '%m:%i:%z' "$f" 2>/dev/null || true
+}
 _envoke_check_unload() {
-  local token
-  token="$(_envoke_unload_token)" || return 0
-  [ "${_ENVOKE_LAST_UNLOAD_TOKEN:-}" = "$token" ] && return 0
-  _ENVOKE_LAST_UNLOAD_TOKEN="$token"
-  eval "$(command envoke unload 2>/dev/null)" 2>/dev/null || true
+  local t; t="$(_envoke_unload_token)" || return 0
+  [ "${_ENVOKE_LAST_UNLOAD_TOKEN:-}" = "$t" ] && return 0
+  _ENVOKE_LAST_UNLOAD_TOKEN="$t"
+  command envoke unload 2>/dev/null | grep -v '^trap ' | eval "$(cat)"
 }
 _ENVOKE_LAST_UNLOAD_TOKEN="$(_envoke_unload_token 2>/dev/null || true)"
-
-# ── install prompt hooks ───────────────────────────────────────────────────────
-if [ -n "${ZSH_VERSION:-}" ]; then
-  autoload -Uz add-zsh-hook 2>/dev/null
-  add-zsh-hook precmd _envoke_check_unload
-else
-  PROMPT_COMMAND="_envoke_check_unload${PROMPT_COMMAND:+; $PROMPT_COMMAND}"
-fi
-
-# ── combined watcher + EXIT trap ───────────────────────────────────────────────
-if [ -z "${_ENVOKE_WATCH_PID:-}" ]; then
-  command envoke watch &
-  _ENVOKE_WATCH_PID=$!
-  trap 'eval "$(command envoke unload 2>/dev/null || true)"; kill "${_ENVOKE_WATCH_PID:-}" 2>/dev/null; command envoke clear-cache 2>/dev/null' EXIT
-fi
+[ -n "${ZSH_VERSION:-}" ] && { autoload -Uz add-zsh-hook 2>/dev/null; add-zsh-hook precmd _envoke_check_unload; } || PROMPT_COMMAND="_envoke_check_unload${PROMPT_COMMAND:+; $PROMPT_COMMAND}"
+[ -z "${_ENVOKE_WATCH_PID:-}" ] && { command envoke watch & _ENVOKE_WATCH_PID=$!; trap 'command envoke unload 2>/dev/null | eval "$(cat)"; kill "${_ENVOKE_WATCH_PID:-}" 2>/dev/null; command envoke clear-cache 2>/dev/null' EXIT; }
 `
 
 // fishCombinedInitScript is the combined shell snippet for fish.
 const fishCombinedInitScript = `
-# envoke shell integration for fish — add to ~/.config/fish/config.fish:
-#   envoke shell-init --shell fish | source
-
 function envoke
   switch $argv[1]
-    case resolve
-      # Help/version: print directly, do not source.
-      if contains -- --help $argv; or contains -- -h $argv
-        command envoke resolve $argv[2..]
-        return
-      end
-      set -l _envoke_out (command envoke resolve $argv[2..])
-      set -l _envoke_exit $status
-      test $_envoke_exit -ne 0; and return $_envoke_exit
-      # Strip the standalone EXIT trap — the shell-init cleanup covers it.
-      printf '%s\n' $_envoke_out | grep -v '^trap ' | source
-    case unload
-      if contains -- --help $argv; or contains -- -h $argv
-        command envoke unload $argv[2..]
-        return
-      end
-      set -l _envoke_out (command envoke unload)
-      set -l _envoke_exit $status
-      test $_envoke_exit -ne 0; and return $_envoke_exit
-      printf '%s\n' $_envoke_out | grep -v '^trap ' | source
-    case switch
-      set -l _envoke_out (command envoke switch $argv[2..])
-      set -l _envoke_exit $status
-      test $_envoke_exit -ne 0; and return $_envoke_exit
-      printf '%s\n' $_envoke_out | grep -v '^trap ' | source
-      set -g _ENVOKE_LAST_UNLOAD_TOKEN (_envoke_unload_token 2>/dev/null; or echo "")
-    case '*'
-      command envoke $argv
+    case resolve; envoke_eval resolve $argv[2..]
+    case unload; envoke_eval unload
+    case switch; envoke_eval switch $argv[2..]; set -g _ENVOKE_LAST_UNLOAD_TOKEN (_envoke_unload_token 2>/dev/null; or echo "")
+    case '*'; command envoke $argv
   end
 end
-
-function _envoke_unload_token
-  set -l f1 /dev/shm/renv-(id -u)-unload-requested
-  test -f $f1; or set f1 /tmp/renv-(id -u)-unload-requested
-  set -l f2 /dev/shm/kctx-(id -u)-unload-requested
-  test -f $f2; or set f2 /tmp/kctx-(id -u)-unload-requested
-  set -l t1 ""
-  set -l t2 ""
-  test -f $f1; and set t1 (stat -c '%Y:%i:%s' $f1 2>/dev/null; or stat -f '%m:%i:%z' $f1 2>/dev/null; or echo "")
-  test -f $f2; and set t2 (stat -c '%Y:%i:%s' $f2 2>/dev/null; or stat -f '%m:%i:%z' $f2 2>/dev/null; or echo "")
-  test -z "$t1" -a -z "$t2"; and return 1
-  printf '%s|%s\n' $t1 $t2
+function envoke_eval
+  set -l _cmd $argv[1]
+  set -l _args $argv[2..]
+  for _arg in $_args
+    if test "$_arg" = "--help" -o "$_arg" = "-h" -o "$_arg" = "--version"; command envoke $_cmd $_args; return; end
+  end
+  set -l _out (command envoke $_cmd $_args); set -l _exit $status
+  test $_exit -ne 0; and return $_exit
+  printf '%s\n' $_out | grep -v '^trap ' | source
 end
-
+function _envoke_unload_token
+  set -l f {{SECUREDIR}}/envoke-(id -u)-unload-requested
+  test -f $f; and stat -c '%Y:%i:%s' $f 2>/dev/null || stat -f '%m:%i:%z' $f 2>/dev/null || echo ""
+end
 function _envoke_check_unload --on-event fish_prompt
-  set -l token (_envoke_unload_token 2>/dev/null); or return
-  test "$_ENVOKE_LAST_UNLOAD_TOKEN" = "$token"; and return
-  set -g _ENVOKE_LAST_UNLOAD_TOKEN $token
+  set -l t (_envoke_unload_token); or return
+  test "$_ENVOKE_LAST_UNLOAD_TOKEN" = "$t"; and return
+  set -g _ENVOKE_LAST_UNLOAD_TOKEN $t
   command envoke unload 2>/dev/null | grep -v '^trap ' | source 2>/dev/null; or true
 end
 set -g _ENVOKE_LAST_UNLOAD_TOKEN (_envoke_unload_token 2>/dev/null; or echo "")
-
-if not set -q _ENVOKE_WATCH_PID
-  command envoke watch &
-  set -gx _ENVOKE_WATCH_PID $last_pid
-end
-
-function _envoke_cleanup --on-event fish_exit
-  command envoke unload 2>/dev/null | grep -v '^trap ' | source 2>/dev/null; or true
-  if set -q _ENVOKE_WATCH_PID
-    kill $_ENVOKE_WATCH_PID 2>/dev/null; or true
-    set -e _ENVOKE_WATCH_PID
-  end
-  command envoke clear-cache 2>/dev/null; or true
-end
+test -n "$_ENVOKE_WATCH_PID"; or { command envoke watch &; set -gx _ENVOKE_WATCH_PID $last_pid; }
 `
 
 // ── clear-cache + watch ───────────────────────────────────────────────────────

--- a/cmd/envoke/main.go
+++ b/cmd/envoke/main.go
@@ -752,7 +752,7 @@ const bashCombinedInitScript = `
 envoke() {
   case "$1" in
     resolve) envoke_eval resolve "${@:2}" ;;
-    unload) envoke_eval unload ;;
+    unload) envoke_eval unload "${@:2}" ;;
     switch) envoke_eval switch "${@:2}"; _ENVOKE_LAST_UNLOAD_TOKEN="$(_envoke_unload_token 2>/dev/null || true)" ;;
     *) command envoke "$@" ;;
   esac
@@ -768,7 +768,7 @@ envoke_eval() {
 _envoke_unload_token() {
   local f="{{SECUREDIR}}/envoke-${UID}-unload-requested"
   [ -f "$f" ] || return 1
-  stat -c '%Y:%i:%s' "$f" 2>/dev/null || stat -f '%m:%i:%z' "$f" 2>/dev/null || true
+  stat -c '%Y:%i:%s' "$f" 2>/dev/null || stat -f '%m:%i:%z' "$f" 2>/dev/null || echo "exists"
 }
 _envoke_check_unload() {
   local t; t="$(_envoke_unload_token)" || return 0
@@ -786,7 +786,7 @@ const fishCombinedInitScript = `
 function envoke
   switch $argv[1]
     case resolve; envoke_eval resolve $argv[2..]
-    case unload; envoke_eval unload
+    case unload; envoke_eval unload $argv[2..]
     case switch; envoke_eval switch $argv[2..]; set -g _ENVOKE_LAST_UNLOAD_TOKEN (_envoke_unload_token 2>/dev/null; or echo "")
     case '*'; command envoke $argv
   end
@@ -802,15 +802,23 @@ function envoke_eval
   printf '%s\n' $_out | grep -v '^trap ' | source
 end
 function _envoke_unload_token
-  set -l f {{SECUREDIR}}/envoke-(id -u)-unload-requested
-  test -f $f; or return 1
-  stat -c '%Y:%i:%s' $f 2>/dev/null; or stat -f '%m:%i:%z' $f 2>/dev/null; or true
+  set -l f "{{SECUREDIR}}/envoke-(id -u)-unload-requested"
+  test -f "$f"; or return 1
+  stat -c '%Y:%i:%s' "$f" 2>/dev/null; or stat -f '%m:%i:%z' "$f" 2>/dev/null; or echo "exists"
 end
 function _envoke_check_unload --on-event fish_prompt
   set -l t (_envoke_unload_token); or return
   test "$_ENVOKE_LAST_UNLOAD_TOKEN" = "$t"; and return
   set -g _ENVOKE_LAST_UNLOAD_TOKEN $t
   command envoke unload 2>/dev/null | grep -v '^trap ' | source 2>/dev/null; or true
+end
+function _envoke_cleanup --on-event fish_exit
+  if test -n "$_ENVOKE_WATCH_PID"
+    kill -0 $_ENVOKE_WATCH_PID 2>/dev/null; and kill $_ENVOKE_WATCH_PID 2>/dev/null; or true
+    set -e _ENVOKE_WATCH_PID
+  end
+  command envoke unload 2>/dev/null | grep -v '^trap ' | source 2>/dev/null; or true
+  command envoke clear-cache >/dev/null 2>/dev/null; or true
 end
 set -g _ENVOKE_LAST_UNLOAD_TOKEN (_envoke_unload_token 2>/dev/null; or echo "")
 test -n "$_ENVOKE_WATCH_PID"; or { command envoke watch &; set -gx _ENVOKE_WATCH_PID $last_pid; }

--- a/cmd/envoke/main.go
+++ b/cmd/envoke/main.go
@@ -766,18 +766,23 @@ envoke_eval() {
   eval "$(printf '%s\n' "$_out" | grep -v '^trap ')"
 }
 _envoke_unload_token() {
-  local f="{{SECUREDIR}}/envoke-${UID}-unload-requested"
-  [ -f "$f" ] && stat -c '%Y:%i:%s' "$f" 2>/dev/null || stat -f '%m:%i:%z' "$f" 2>/dev/null || true
+  local f1="{{SECUREDIR}}/renv-${UID}-unload-requested"
+  local f2="{{SECUREDIR}}/kctx-${UID}-unload-requested"
+  local t1="" t2=""
+  [ -f "$f1" ] && t1="$(stat -c '%Y:%i:%s' "$f1" 2>/dev/null || stat -f '%m:%i:%z' "$f1" 2>/dev/null || true)"
+  [ -f "$f2" ] && t2="$(stat -c '%Y:%i:%s' "$f2" 2>/dev/null || stat -f '%m:%i:%z' "$f2" 2>/dev/null || true)"
+  [ -z "$t1" ] && [ -z "$t2" ] && return 1
+  printf '%s|%s\n' "$t1" "$t2"
 }
 _envoke_check_unload() {
   local t; t="$(_envoke_unload_token)" || return 0
   [ "${_ENVOKE_LAST_UNLOAD_TOKEN:-}" = "$t" ] && return 0
   _ENVOKE_LAST_UNLOAD_TOKEN="$t"
-  command envoke unload 2>/dev/null | grep -v '^trap ' | eval "$(cat)"
+  eval "$(command envoke unload 2>/dev/null | grep -v '^trap ')"
 }
 _ENVOKE_LAST_UNLOAD_TOKEN="$(_envoke_unload_token 2>/dev/null || true)"
 [ -n "${ZSH_VERSION:-}" ] && { autoload -Uz add-zsh-hook 2>/dev/null; add-zsh-hook precmd _envoke_check_unload; } || PROMPT_COMMAND="_envoke_check_unload${PROMPT_COMMAND:+; $PROMPT_COMMAND}"
-[ -z "${_ENVOKE_WATCH_PID:-}" ] && { command envoke watch & _ENVOKE_WATCH_PID=$!; trap 'command envoke unload 2>/dev/null | eval "$(cat)"; kill "${_ENVOKE_WATCH_PID:-}" 2>/dev/null; command envoke clear-cache 2>/dev/null' EXIT; }
+[ -z "${_ENVOKE_WATCH_PID:-}" ] && { command envoke watch & _ENVOKE_WATCH_PID=$!; trap 'eval "$(command envoke unload 2>/dev/null | grep -v '"'"'^trap '"'"')"; kill "${_ENVOKE_WATCH_PID:-}" 2>/dev/null; command envoke clear-cache 2>/dev/null' EXIT; }
 `
 
 // fishCombinedInitScript is the combined shell snippet for fish.
@@ -801,8 +806,14 @@ function envoke_eval
   printf '%s\n' $_out | grep -v '^trap ' | source
 end
 function _envoke_unload_token
-  set -l f {{SECUREDIR}}/envoke-(id -u)-unload-requested
-  test -f $f; and stat -c '%Y:%i:%s' $f 2>/dev/null || stat -f '%m:%i:%z' $f 2>/dev/null || echo ""
+  set -l uid (id -u)
+  set -l f1 {{SECUREDIR}}/renv-$uid-unload-requested
+  set -l f2 {{SECUREDIR}}/kctx-$uid-unload-requested
+  set -l t1 ""; set -l t2 ""
+  test -f $f1; and set t1 (stat -c '%Y:%i:%s' $f1 2>/dev/null; or stat -f '%m:%i:%z' $f1 2>/dev/null; or echo "")
+  test -f $f2; and set t2 (stat -c '%Y:%i:%s' $f2 2>/dev/null; or stat -f '%m:%i:%z' $f2 2>/dev/null; or echo "")
+  test -z "$t1" -a -z "$t2"; and return 1
+  printf '%s|%s\n' $t1 $t2
 end
 function _envoke_check_unload --on-event fish_prompt
   set -l t (_envoke_unload_token); or return

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/muesli/termenv v0.16.0
 	github.com/spf13/cobra v1.10.2
-	golang.org/x/crypto v0.49.0
 	golang.org/x/term v0.41.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,6 @@ github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3A
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
-golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/kubeconfig/tmpfile.go
+++ b/internal/kubeconfig/tmpfile.go
@@ -110,9 +110,9 @@ func ClearTrackedNames(uid string) error {
 }
 
 // UnloadRequestFile returns the path of the sentinel file used to signal
-// shells to run kctx unload on their next prompt draw.
+// shells to run envoke unload on their next prompt draw.
 func UnloadRequestFile(uid string) string {
-	return filepath.Join(securedir.Dir(), "kctx-"+uid+"-unload-requested")
+	return filepath.Join(securedir.Dir(), "envoke-"+uid+"-unload-requested")
 }
 
 // RequestUnload creates the sentinel file. Shell PROMPT_COMMAND/precmd hooks

--- a/internal/state/vars.go
+++ b/internal/state/vars.go
@@ -60,9 +60,9 @@ func ClearVarNames(uid string) error {
 }
 
 // UnloadRequestFile returns the path of the sentinel file used to signal
-// shells to run renv unload on their next prompt draw.
+// shells to run envoke unload on their next prompt draw.
 func UnloadRequestFile(uid string) string {
-	return filepath.Join(securedir.Dir(), "renv-"+uid+"-unload-requested")
+	return filepath.Join(securedir.Dir(), "envoke-"+uid+"-unload-requested")
 }
 
 // RequestUnload creates the sentinel file. Shell PROMPT_COMMAND/precmd hooks


### PR DESCRIPTION
Closes #55

## Problem

`envoke shell-init` emitted a large, noisy script (~148 lines bash/zsh, ~115 lines fish) with overlapping functions, duplicated eval logic, hardcoded `/dev/shm`/`/tmp` paths, and separate watcher blocks for renv, kctx, and envoke — making it hard to read, maintain, and audit.

## Changes

- `cmd/envoke/main.go`: replaced bash/zsh and fish init scripts with minimal versions (~29 and ~30 lines respectively)
  - Single `envoke()` wrapper with case dispatch
  - Single `envoke_eval()` helper handling the capture/check-exit/eval-non-trap pattern
  - Single `_envoke_unload_token()` watching one unified sentinel file
  - Single prompt hook (`precmd` / `PROMPT_COMMAND`)
  - Single watcher guard (`_ENVOKE_WATCH_PID`) and EXIT trap
  - `{{SECUREDIR}}` placeholder substituted at emit time via `strings.ReplaceAll`
- `internal/state/vars.go`: `UnloadRequestFile` now writes `envoke-<uid>-unload-requested`
- `internal/kubeconfig/tmpfile.go`: `UnloadRequestFile` now writes `envoke-<uid>-unload-requested`

## Why

The script had accumulated cruft from the renv/kctx split that never got cleaned up when the unified `envoke` surface landed. The two sentinel files (`renv-<uid>-unload-requested` and `kctx-<uid>-unload-requested`) were functionally identical signals — unifying them to `envoke-<uid>-unload-requested` removes the last place the shell has to know about the renv/kctx distinction. Paths are now resolved by the Go binary at emit time (using `securedir.Dir()`) rather than hardcoded in the emitted shell script, which is both more correct and more portable.

## How to verify

1. `eval "$(envoke shell-init)"` — confirm the shell function is defined
2. `envoke resolve <env-file>` — confirm secrets load into the current shell
3. `envoke unload` — confirm env vars are cleared
4. `envoke switch <context>` — confirm kubeconfig switches
5. Trigger a sleep/lock event (or manually `touch $(envoke shell-init | grep securedir || echo /dev/shm)/envoke-$(id -u)-unload-requested`) and confirm the next prompt fires `envoke unload`
6. Exit the shell — confirm the watcher process is killed and cache is cleared