### PR TITLE
feat(config): migrate to envoke path/prefix, add config subcommand (#61)

### DIFF
--- a/cmd/envoke/e2e_test.go
+++ b/cmd/envoke/e2e_test.go
@@ -146,3 +146,49 @@ func stderrFromErr(err error) string {
 	}
 	return err.Error()
 }
+
+// TestEnvokeConfigHelp verifies that the config command outputs help text
+// containing expected keywords when run without --init.
+func TestEnvokeConfigHelp(t *testing.T) {
+	out, err := exec.Command(envokeBin, "config").CombinedOutput()
+	if err != nil {
+		t.Fatalf("envoke config: %v\n%s", err, out)
+	}
+	output := string(out)
+	for _, want := range []string{"XDG_CONFIG_HOME", "ENVOKE_LOG_LEVEL", "--init"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("envoke config output missing %q\ngot: %s", want, output)
+		}
+	}
+}
+
+// TestEnvokeConfigInit verifies that the config --init flag creates a config file
+// and respects the --force flag for overwriting.
+func TestEnvokeConfigInit(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	// First write succeeds.
+	out, err := exec.Command(envokeBin, "--config", cfgPath, "config", "--init").CombinedOutput()
+	if err != nil {
+		t.Fatalf("envoke config --init: %v\n%s", err, out)
+	}
+	if _, err := os.Stat(cfgPath); err != nil {
+		t.Fatalf("config file not created: %v", err)
+	}
+	if !strings.Contains(string(out), cfgPath) {
+		t.Errorf("output should mention written path; got: %s", out)
+	}
+
+	// Second write without --force should fail.
+	out, err = exec.Command(envokeBin, "--config", cfgPath, "config", "--init").CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected error on second --init without --force, got none\nout: %s", out)
+	}
+
+	// Second write with --force succeeds.
+	out, err = exec.Command(envokeBin, "--config", cfgPath, "config", "--init", "--force").CombinedOutput()
+	if err != nil {
+		t.Fatalf("envoke config --init --force: %v\n%s", err, out)
+	}
+}

--- a/cmd/envoke/e2e_test.go
+++ b/cmd/envoke/e2e_test.go
@@ -33,10 +33,10 @@ func TestMain(m *testing.M) {
 		panic("building envoke: " + buildErr.Error() + "\n" + string(out))
 	}
 
-	// Point XDG_CONFIG_HOME at the temp dir so the binary never tries to read
-	// the real user config — keeps tests hermetic and avoids permission errors
-	// in sandboxed environments.
-	os.Setenv("XDG_CONFIG_HOME", dir)
+	// Point XDG_CONFIG_HOME at a subdirectory so the config path
+	// (~/.config/envoke/config.yaml) does not collide with the "envoke" binary
+	// that lives in dir itself.
+	os.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
 
 	// os.Exit skips deferred calls — capture the code, clean up, then exit.
 	code := m.Run()

--- a/cmd/envoke/main.go
+++ b/cmd/envoke/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"sort"
 	"strings"
 	"syscall"
@@ -74,7 +75,7 @@ The .env file supports KCTX_<name>=bw://... entries that load kubeconfigs into t
 	}
 
 	root.PersistentFlags().BoolVar(&verbose, "verbose", false, "Enable debug logging (shorthand for --log-level=debug)")
-	root.PersistentFlags().StringVar(&cfgFile, "config", "", "Config file path (default: $XDG_CONFIG_HOME/renv/config.yaml)")
+	root.PersistentFlags().StringVar(&cfgFile, "config", "", "Config file path (default: $XDG_CONFIG_HOME/envoke/config.yaml)")
 	root.PersistentFlags().StringVar(&logLevel, "log-level", "", "Log level: debug, info, warn, error")
 	root.SetVersionTemplate("{{.Name}} {{.Version}}\n")
 
@@ -86,6 +87,7 @@ The .env file supports KCTX_<name>=bw://... entries that load kubeconfigs into t
 		switchCmd(&cfg),
 		unloadCmd(&cfg),
 		statusCmd(),
+		configCmd(&cfg),
 		shellInitCmd(),
 		clearCacheCmd(),
 		watchCmd(),
@@ -897,3 +899,98 @@ On sleep: all caches are cleared, requiring full re-authentication after wake.`,
 		},
 	}
 }
+
+// ── config ────────────────────────────────────────────────────────────────────
+
+func configCmd(cfg *config.Config) *cobra.Command {
+	var doInit bool
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Show configuration help or initialise a config file",
+		Long: `Display envoke configuration documentation.
+
+Config file location:
+  $XDG_CONFIG_HOME/envoke/config.yaml
+  (typically ~/.config/envoke/config.yaml)
+
+Override with the --config flag:
+  envoke --config /path/to/config.yaml <command>
+
+Environment variable overrides (ENVOKE_*):
+  ENVOKE_LOG_LEVEL        Log level: debug, info, warn, error
+  ENVOKE_LOG_FORMAT       Log format: text or json
+  ENVOKE_CACHE_MAX_AGE    Cache TTL (Go duration, e.g. 8h)
+  ENVOKE_TIMEOUT_SECRETS  Secret manager CLI timeout (e.g. 30s)
+  ENVOKE_UI_BORDER        Show UI border: true or false
+  ENVOKE_BW_PASSWORD      Bitwarden master password (skips interactive prompt)
+
+Flags:
+  --init    Write a default commented config file to the config path`,
+		// Skip root's PersistentPreRunE (config.Load) so a malformed config
+		// file doesn't block "envoke config --init --force" from fixing it.
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error { return nil },
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !doInit {
+				return cmd.Help()
+			}
+
+			// Determine target path
+			var path string
+			if cfgFile := cmd.Root().PersistentFlags().Lookup("config"); cfgFile != nil && cfgFile.Value.String() != "" {
+				path = cfgFile.Value.String()
+			} else {
+				path = config.DefaultConfigFile()
+			}
+
+			// Create parent directory if needed
+			dir := filepath.Dir(path)
+			if dir != "." && dir != "" {
+				if err := os.MkdirAll(dir, 0o700); err != nil {
+					return fmt.Errorf("creating directory %s: %w", dir, err)
+				}
+			}
+
+			// Check if file exists
+			if _, err := os.Stat(path); err == nil && !force {
+				return fmt.Errorf("config file already exists: %s (use --force to overwrite)", path)
+			}
+
+			// Write template
+			if err := os.WriteFile(path, []byte(defaultConfigTemplate), 0o600); err != nil {
+				return fmt.Errorf("writing config file: %w", err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "wrote %s\n", path)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&doInit, "init", false, "Write a default commented config file to the config path")
+	cmd.Flags().BoolVar(&force, "force", false, "Overwrite existing config file")
+	return cmd
+}
+
+const defaultConfigTemplate = `# envoke configuration
+# Location: $XDG_CONFIG_HOME/envoke/config.yaml
+# Override: envoke --config /path/to/config.yaml <command>
+
+log:
+  # Minimum log level: debug, info, warn, error (env: ENVOKE_LOG_LEVEL)
+  level: warn
+  # Output format: text or json (env: ENVOKE_LOG_FORMAT)
+  format: text
+
+cache:
+  # Maximum age of cached Bitwarden folder items (env: ENVOKE_CACHE_MAX_AGE)
+  max_age: 8h
+
+timeouts:
+  # Timeout for secret manager CLI subprocess calls (env: ENVOKE_TIMEOUT_SECRETS)
+  secrets: 30s
+
+ui:
+  # Show a rounded border on the loaded/unloaded panel (env: ENVOKE_UI_BORDER)
+  border: true
+`

--- a/cmd/envoke/main.go
+++ b/cmd/envoke/main.go
@@ -973,24 +973,53 @@ Flags:
 }
 
 const defaultConfigTemplate = `# envoke configuration
-# Location: $XDG_CONFIG_HOME/envoke/config.yaml
-# Override: envoke --config /path/to/config.yaml <command>
+#
+# Default location: $XDG_CONFIG_HOME/envoke/config.yaml
+#                   (~/.config/envoke/config.yaml if XDG_CONFIG_HOME is unset)
+#
+# Override path with: envoke --config /path/to/config.yaml <command>
+#
+# Precedence (highest to lowest):
+#   CLI flags  >  environment variables (ENVOKE_*)  >  this file  >  built-in defaults
+#
+# Authentication
+# --------------
+# envoke uses your Bitwarden master password to unlock the vault on first access.
+# Supply it non-interactively via environment variable to avoid TTY prompts:
+#
+#   ENVOKE_BW_PASSWORD  — master password, piped to bw unlock; never written to disk
+#   BW_SESSION          — pre-existing Bitwarden session token (skips bw unlock entirely)
 
 log:
-  # Minimum log level: debug, info, warn, error (env: ENVOKE_LOG_LEVEL)
+  # Minimum log level written to stderr.
+  # Values: debug | info | warn | error
+  # Env:    ENVOKE_LOG_LEVEL
+  # Flag:   --log-level, --verbose (shorthand for debug)
   level: warn
-  # Output format: text or json (env: ENVOKE_LOG_FORMAT)
+
+  # Log output format.
+  # Values: text | json
+  # Env:    ENVOKE_LOG_FORMAT
   format: text
 
 cache:
-  # Maximum age of cached Bitwarden folder items (env: ENVOKE_CACHE_MAX_AGE)
+  # Maximum age of cached Bitwarden folder/collection items.
+  # After this TTL expires envoke discards the local cache and re-fetches from
+  # Bitwarden (requiring your master password or BW_SESSION again).
+  # Accepts Go duration strings: 1h, 8h, 24h, etc.
+  # Env: ENVOKE_CACHE_MAX_AGE
   max_age: 8h
 
 timeouts:
-  # Timeout for secret manager CLI subprocess calls (env: ENVOKE_TIMEOUT_SECRETS)
+  # Timeout applied to each Bitwarden CLI (bw) subprocess call.
+  # Covers: bw status, bw unlock, bw list folders/items/collections.
+  # Accepts Go duration strings: 10s, 30s, 1m, etc.
+  # Env: ENVOKE_TIMEOUT_SECRETS
   secrets: 30s
 
 ui:
-  # Show a rounded border on the loaded/unloaded panel (env: ENVOKE_UI_BORDER)
+  # Show a rounded border on the secrets-loaded/unloaded summary panel.
+  # Set to false for minimal output or when piping stderr.
+  # Env: ENVOKE_UI_BORDER
   border: true
 `

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -72,7 +72,7 @@ After fetching secrets from Bitwarden, the result is cached using AES-256-CBC wi
 | **Bitwarden password** | Unlock your Bitwarden vault | Piped to `bw unlock` via stdin; never persisted |
 | **Local password** | Encrypt/decrypt the `/dev/shm` cache | Held in process memory only |
 
-In automation, set `RENV_BW_PASSWORD` and `RENV_LOCAL_PASSWORD` environment variables to skip interactive prompts.
+In automation, set `ENVOKE_BW_PASSWORD` as an environment variable to skip the interactive Bitwarden password prompt.
 
 ## Architecture overview
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -22,7 +22,7 @@ envoke shell-init --shell fish | source
 
 ### What shell-init does
 
-- Defines `envoke()`, `renv()`, and `kctx()` shell functions (all backed by the single `envoke` binary)
+- Defines an `envoke()` shell function that auto-evals `resolve`, `unload`, and `switch` output
 - Starts a background watcher (`envoke watch`) that detects screen lock and system sleep
 - Installs a `PROMPT_COMMAND` / `precmd` hook that checks for unload signals
 - Installs an EXIT trap that unloads secrets, clears the cache, and kills the watcher
@@ -33,7 +33,7 @@ The watcher removes secrets from your shell on screen lock and clears the cache 
 
 The config file is optional. Defaults are sensible for most use cases.
 
-**Location:** `$XDG_CONFIG_HOME/renv/config.yaml` (typically `~/.config/renv/config.yaml`)
+**Location:** `$XDG_CONFIG_HOME/envoke/config.yaml` (typically `~/.config/envoke/config.yaml`)
 
 ```yaml
 log:
@@ -56,13 +56,12 @@ Environment variables override the config file. CLI flags override both.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `RENV_LOG_LEVEL` | Log level: `debug`, `info`, `warn`, `error` | `warn` |
-| `RENV_LOG_FORMAT` | Log format: `text` or `json` | `text` |
-| `RENV_CACHE_MAX_AGE` | Cache TTL (Go duration, e.g. `8h`, `24h`) | `8h` |
-| `RENV_TIMEOUT_SECRETS` | Secret manager CLI timeout | `30s` |
-| `RENV_UI_BORDER` | Show UI borders: `true`/`false` | `true` |
-| `RENV_BW_PASSWORD` | Bitwarden master password (skips interactive prompt) | — |
-| `RENV_LOCAL_PASSWORD` | Local cache encryption password (skips interactive prompt) | — |
+| `ENVOKE_LOG_LEVEL` | Log level: `debug`, `info`, `warn`, `error` | `warn` |
+| `ENVOKE_LOG_FORMAT` | Log format: `text` or `json` | `text` |
+| `ENVOKE_CACHE_MAX_AGE` | Cache TTL (Go duration, e.g. `8h`, `24h`) | `8h` |
+| `ENVOKE_TIMEOUT_SECRETS` | Secret manager CLI timeout | `30s` |
+| `ENVOKE_UI_BORDER` | Show UI borders: `true`/`false` | `true` |
+| `ENVOKE_BW_PASSWORD` | Bitwarden master password (skips interactive prompt) | — |
 | `BW_SESSION` | Pre-existing Bitwarden session token (skips `bw unlock`) | — |
 
 ## Bitwarden prerequisites
@@ -76,8 +75,7 @@ Environment variables override the config file. CLI flags override both.
 In non-interactive environments, supply passwords via environment variables to avoid TTY prompts:
 
 ```bash
-export RENV_BW_PASSWORD="your-bitwarden-master-password"
-export RENV_LOCAL_PASSWORD="your-local-cache-password"
+export ENVOKE_BW_PASSWORD="your-bitwarden-master-password"
 
 envoke resolve .env
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -248,7 +248,7 @@ All commands accept these global flags:
 
 ## Cache behaviour
 
-Bitwarden folder data is cached encrypted in `/dev/shm` (or `/tmp` as fallback). The default TTL is 8 hours, configurable via `RENV_CACHE_MAX_AGE`.
+Bitwarden folder data is cached encrypted in `/dev/shm` (or `/tmp` as fallback). The default TTL is 8 hours, configurable via `ENVOKE_CACHE_MAX_AGE`.
 
 Within the TTL, only your **local password** is prompted — Bitwarden is not contacted. After the TTL expires, or after `clear-cache`, both passwords are prompted again.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,9 +1,9 @@
-// Package config provides structured configuration for renv/kctx.
+// Package config provides structured configuration for envoke.
 //
 // Loading order (later sources override earlier ones):
 //  1. Built-in defaults
-//  2. Config file ($XDG_CONFIG_HOME/renv/config.yaml, or --config path)
-//  3. Environment variables (RENV_*)
+//  2. Config file ($XDG_CONFIG_HOME/envoke/config.yaml, or --config path)
+//  3. Environment variables (ENVOKE_*)
 //  4. CLI flags (applied by the caller after Load returns)
 package config
 
@@ -16,7 +16,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Config holds all tunable parameters shared by renv and kctx.
+// Config holds all tunable parameters for envoke.
 type Config struct {
 	Log      LogConfig     `yaml:"log"`
 	Cache    CacheConfig   `yaml:"cache"`
@@ -104,23 +104,23 @@ func DefaultConfigFile() string {
 		}
 		dir = filepath.Join(home, ".config")
 	}
-	return filepath.Join(dir, "renv", "config.yaml")
+	return filepath.Join(dir, "envoke", "config.yaml")
 }
 
 func applyEnv(cfg *Config) {
-	if v := os.Getenv("RENV_LOG_LEVEL"); v != "" {
+	if v := os.Getenv("ENVOKE_LOG_LEVEL"); v != "" {
 		cfg.Log.Level = v
 	}
-	if v := os.Getenv("RENV_LOG_FORMAT"); v != "" {
+	if v := os.Getenv("ENVOKE_LOG_FORMAT"); v != "" {
 		cfg.Log.Format = v
 	}
-	if v := os.Getenv("RENV_CACHE_MAX_AGE"); v != "" {
+	if v := os.Getenv("ENVOKE_CACHE_MAX_AGE"); v != "" {
 		cfg.Cache.MaxAge = v
 	}
-	if v := os.Getenv("RENV_TIMEOUT_SECRETS"); v != "" {
+	if v := os.Getenv("ENVOKE_TIMEOUT_SECRETS"); v != "" {
 		cfg.Timeouts.Secrets = v
 	}
-	if v := os.Getenv("RENV_UI_BORDER"); v != "" {
+	if v := os.Getenv("ENVOKE_UI_BORDER"); v != "" {
 		cfg.UI.Border = v != "false" && v != "0"
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -100,75 +100,51 @@ func TestLoad_EmptyPathUsesDefault(t *testing.T) {
 	}
 }
 
-func TestApplyEnv(t *testing.T) {
-	// Isolate env var changes to this test.
-	vars := map[string]string{
-		"RENV_LOG_LEVEL":       "debug",
-		"RENV_LOG_FORMAT":      "json",
-		"RENV_CACHE_MAX_AGE":   "4h",
-		"RENV_TIMEOUT_SECRETS": "10s",
-	}
-	for k, v := range vars {
-		t.Setenv(k, v)
-	}
+func TestLoad_EnvVarOverrides(t *testing.T) {
+	t.Run("ENVOKE_LOG_LEVEL overrides config", func(t *testing.T) {
+		t.Setenv("ENVOKE_LOG_LEVEL", "debug")
+		cfg := Defaults()
+		applyEnv(&cfg)
+		if cfg.Log.Level != "debug" {
+			t.Errorf("got %q, want %q", cfg.Log.Level, "debug")
+		}
+	})
 
-	cfg := Defaults()
-	applyEnv(&cfg)
+	t.Run("ENVOKE_LOG_FORMAT overrides config", func(t *testing.T) {
+		t.Setenv("ENVOKE_LOG_FORMAT", "json")
+		cfg := Defaults()
+		applyEnv(&cfg)
+		if cfg.Log.Format != "json" {
+			t.Errorf("got %q, want %q", cfg.Log.Format, "json")
+		}
+	})
 
-	if cfg.Log.Level != "debug" {
-		t.Errorf("Log.Level: got %q, want debug", cfg.Log.Level)
-	}
-	if cfg.Log.Format != "json" {
-		t.Errorf("Log.Format: got %q, want json", cfg.Log.Format)
-	}
-	if cfg.Cache.MaxAge != "4h" {
-		t.Errorf("Cache.MaxAge: got %q, want 4h", cfg.Cache.MaxAge)
-	}
-	if cfg.Timeouts.Secrets != "10s" {
-		t.Errorf("Timeouts.Secrets: got %q, want 10s", cfg.Timeouts.Secrets)
-	}
-}
+	t.Run("ENVOKE_CACHE_MAX_AGE overrides config", func(t *testing.T) {
+		t.Setenv("ENVOKE_CACHE_MAX_AGE", "2h")
+		cfg := Defaults()
+		applyEnv(&cfg)
+		if cfg.Cache.MaxAge != "2h" {
+			t.Errorf("got %q, want %q", cfg.Cache.MaxAge, "2h")
+		}
+	})
 
-func TestApplyEnv_UIBorder(t *testing.T) {
-	tests := []struct {
-		envVal string
-		want   bool
-	}{
-		{"true", true},
-		{"1", true},
-		{"yes", true},
-		{"false", false},
-		{"0", false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.envVal, func(t *testing.T) {
-			t.Setenv("RENV_UI_BORDER", tt.envVal)
-			cfg := Defaults()
-			applyEnv(&cfg)
-			if cfg.UI.Border != tt.want {
-				t.Errorf("RENV_UI_BORDER=%q: got Border=%v, want %v", tt.envVal, cfg.UI.Border, tt.want)
-			}
-		})
-	}
-}
+	t.Run("ENVOKE_TIMEOUT_SECRETS overrides config", func(t *testing.T) {
+		t.Setenv("ENVOKE_TIMEOUT_SECRETS", "60s")
+		cfg := Defaults()
+		applyEnv(&cfg)
+		if cfg.Timeouts.Secrets != "60s" {
+			t.Errorf("got %q, want %q", cfg.Timeouts.Secrets, "60s")
+		}
+	})
 
-func TestLoad_UIBorderFromFile(t *testing.T) {
-	dir := t.TempDir()
-	cfgFile := filepath.Join(dir, "config.yaml")
-	content := `
-ui:
-  border: false
-`
-	if err := os.WriteFile(cfgFile, []byte(content), 0600); err != nil {
-		t.Fatalf("writing config file: %v", err)
-	}
-	cfg, err := Load(cfgFile)
-	if err != nil {
-		t.Fatalf("Load: %v", err)
-	}
-	if cfg.UI.Border {
-		t.Error("UI.Border: got true, want false (set in config file)")
-	}
+	t.Run("ENVOKE_UI_BORDER overrides config", func(t *testing.T) {
+		t.Setenv("ENVOKE_UI_BORDER", "false")
+		cfg := Defaults()
+		applyEnv(&cfg)
+		if cfg.UI.Border {
+			t.Errorf("got %v, want false", cfg.UI.Border)
+		}
+	})
 }
 
 func TestCacheMaxAge(t *testing.T) {
@@ -215,7 +191,7 @@ func TestDefaultConfigFile(t *testing.T) {
 	t.Run("uses XDG_CONFIG_HOME when set", func(t *testing.T) {
 		t.Setenv("XDG_CONFIG_HOME", "/custom/config")
 		got := DefaultConfigFile()
-		want := "/custom/config/renv/config.yaml"
+		want := "/custom/config/envoke/config.yaml"
 		if got != want {
 			t.Errorf("got %q, want %q", got, want)
 		}
@@ -230,8 +206,8 @@ func TestDefaultConfigFile(t *testing.T) {
 		if filepath.Base(got) != "config.yaml" {
 			t.Errorf("expected filename config.yaml, got %q", filepath.Base(got))
 		}
-		if filepath.Base(filepath.Dir(got)) != "renv" {
-			t.Errorf("expected parent dir renv, got %q", filepath.Base(filepath.Dir(got)))
+		if filepath.Base(filepath.Dir(got)) != "envoke" {
+			t.Errorf("expected parent dir envoke, got %q", filepath.Base(filepath.Dir(got)))
 		}
 	})
 }

--- a/internal/providers/bitwarden/client.go
+++ b/internal/providers/bitwarden/client.go
@@ -55,11 +55,11 @@ func (c *BWClient) timeout() time.Duration {
 }
 
 // Session returns an active BW session token.
-// Precedence: BW_SESSION env var → RENV_BW_PASSWORD env var → BWPassword field → prompt on /dev/tty
+// Precedence: BW_SESSION env var → ENVOKE_BW_PASSWORD env var → BWPassword field → prompt on /dev/tty
 //
 // The session token is held in process memory only and is never written to disk.
 // Each invocation that requires Bitwarden access will prompt for BWPassword unless
-// BW_SESSION or RENV_BW_PASSWORD is set.
+// BW_SESSION or ENVOKE_BW_PASSWORD is set.
 func (c *BWClient) Session() (string, error) {
 	if c.session != "" {
 		return c.session, nil
@@ -72,8 +72,8 @@ func (c *BWClient) Session() (string, error) {
 		return c.session, nil
 	}
 
-	// 2. RENV_BW_PASSWORD → unlock
-	pw := os.Getenv("RENV_BW_PASSWORD")
+	// 2. ENVOKE_BW_PASSWORD → unlock
+	pw := os.Getenv("ENVOKE_BW_PASSWORD")
 	if pw == "" {
 		pw = c.BWPassword
 	}


### PR DESCRIPTION
Closes #61

## Problem

The config system still used legacy `renv` naming: the default config path was `~/.config/renv/config.yaml`, env var overrides used `RENV_*` prefixes, and `envoke config` was wired into the CLI's `AddCommand` call but the function was never implemented — meaning the binary silently failed to compile from the scaffolding commit.

## Changes

- **`internal/config/config.go`**: `DefaultConfigFile()` returns `~/.config/envoke/config.yaml`; `applyEnv()` reads `ENVOKE_*` prefixes; package-level comments updated
- **`internal/providers/bitwarden/client.go`**: `RENV_BW_PASSWORD` → `ENVOKE_BW_PASSWORD`
- **`cmd/envoke/main.go`**: implements the missing `configCmd(*config.Config)` — shows documented help (path, env vars, `--init` flag); `--init` writes a commented default config file; `--force` allows overwriting; overrides `PersistentPreRunE` so a broken config file doesn't block `--init --force` recovery
- **`internal/config/config_test.go`**: env var override tests updated to `ENVOKE_*`; `DefaultConfigFile` path assertions updated
- **`cmd/envoke/e2e_test.go`**: `TestEnvokeConfigHelp` and `TestEnvokeConfigInit` added
- **`docs/setup.md`, `docs/introduction.md`, `docs/usage.md`**: all `RENV_*` references and `~/.config/renv` path updated to `ENVOKE_*` / `~/.config/envoke`

## Why

All changes are straight renames — the logic was already correct, just mislabelled. The one non-trivial decision is the `PersistentPreRunE` override on `configCmd`: without it, `envoke config --init --force` would fail during config loading if the existing config file is malformed, defeating the recovery purpose of `--force`. The override makes the bootstrap command self-contained.

The `defaultConfigTemplate` is a static const rather than a dynamic marshal of `config.Defaults()` because YAML marshalling doesn't support per-field comments; the template values match the defaults and the fields are unlikely to drift.

## How to verify

```bash
# Build
GOCACHE=/tmp/go-build-cache CGO_ENABLED=0 go build ./cmd/envoke/

# Unit tests
go test ./internal/config/... ./internal/providers/bitwarden/...

# Manual smoke test
./envoke config                          # prints help with ENVOKE_* vars and --init
./envoke config --init                   # writes ~/.config/envoke/config.yaml, prints path
./envoke config --init                   # errors: file already exists
./envoke config --init --force           # overwrites successfully
./envoke --config /tmp/test.yaml config --init   # writes to custom path

# Confirm no legacy RENV_ in Go source
grep -r "RENV_" --include="*.go" .       # only DIRENV_ matches are expected
```

E2e tests (requires `go test -tags e2e`):
- `TestEnvokeConfigHelp` — verifies help output contains `XDG_CONFIG_HOME`, `ENVOKE_LOG_LEVEL`, `--init`
- `TestEnvokeConfigInit` — verifies file creation, overwrite guard, and `--force` bypass