### PR TITLE
chore(flake): update vendorHash for Go modules

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
           pname = "envoke";
           version = releaseVersion;
           src = ./.;
-          vendorHash = "sha256-qhStGkBdR1ClZp3Wb0pI9uVZWxejFrvT1G9ujPw8Ubg=";
+          vendorHash = "sha256-LUCRrwakaITrnME5a0tiAp0jsMJQKPtIV8Y8LLwA3LI=";
           subPackages = [ "cmd/envoke" ];
           ldflags = [
             "-s" "-w"


### PR DESCRIPTION
## Problem

The Nix flake `vendorHash` was outdated and no longer matched the current Go module dependencies, causing Nix builds to fail hash verification.

## Changes

- `flake.nix`: updated `vendorHash` from `sha256-qhStGkBdR1ClZp3Wb0pI9uVZWxejFrvT1G9ujPw8Ubg=` to `sha256-LUCRrwakaITrnME5a0tiAp0jsMJQKPtIV8Y8LLwA3LI=`

## Why

Go module dependencies changed (e.g. a new or updated dependency), which invalidates the previous vendor hash. The new hash reflects the current state of the module graph.

## How to verify

1. `nix build` — should complete without hash mismatch errors
2. Confirm the built binary runs: `./result/bin/envoke --version`