### PR TITLE
feat(providers): add config:// URI scheme for YAML config template rendering (#20)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ settings.local.json
 .mcp.json
 human-test/
 .claude/
+.blip/

--- a/cmd/envoke/main.go
+++ b/cmd/envoke/main.go
@@ -171,6 +171,10 @@ The output must be evaluated by your shell:
 
 			sharedReg := newRegistry(cfg)
 			defer sharedReg.Close() //nolint:errcheck // best-effort session cleanup
+			dotenvDir := filepath.Dir(file)
+			cp := providers.NewConfigProvider(dotenvDir, env.RenderConfigTemplate)
+			sharedReg.Register(cp)
+			cp.SetRegistry(sharedReg)
 
 			var kctxPanelEntries []ui.PanelEntry
 			var kubeconfigPath string
@@ -343,6 +347,10 @@ The resolved variables override any same-named variables already in the environm
 			slog.Debug("running exec", "file", file, "command", args[0])
 			reg := newRegistry(cfg)
 			defer reg.Close() //nolint:errcheck // best-effort session cleanup
+			dotenvDir := filepath.Dir(file)
+			cp := providers.NewConfigProvider(dotenvDir, env.RenderConfigTemplate)
+			reg.Register(cp)
+			cp.SetRegistry(reg)
 
 			entries, err := env.ResolveDotEnv(file, reg)
 			if err != nil {
@@ -844,6 +852,7 @@ func clearCacheCmd() *cobra.Command {
 			if err := store.Clear(uid); err != nil {
 				return fmt.Errorf("clearing kubeconfig store: %w", err)
 			}
+			kubeconfig.ClearRendered()
 
 			ui.Success(os.Stderr, "Cache cleared")
 			return nil
@@ -871,6 +880,7 @@ On sleep: all caches are cleared, requiring full re-authentication after wake.`,
 				slog.Debug("cleanup: unloading env variables and kubeconfigs on lock")
 				_ = state.RequestUnload(uid)
 				kubeconfig.ClearManaged()
+				kubeconfig.ClearRendered()
 				_ = kubeconfig.RequestUnload(uid)
 				return nil
 			}); err != nil {
@@ -883,6 +893,7 @@ On sleep: all caches are cleared, requiring full re-authentication after wake.`,
 				_ = state.RequestUnload(uid)
 				store := kubeconfig.NewNamedStore()
 				_ = store.Clear(uid)
+				kubeconfig.ClearRendered()
 				kubeconfig.ClearManaged()
 				_ = kubeconfig.RequestUnload(uid)
 				return nil

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opalbolt/envoke
 
-go 1.25.0
+go 1.25.10
 
 require (
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/internal/env/render.go
+++ b/internal/env/render.go
@@ -1,0 +1,116 @@
+package env
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/opalbolt/envoke/internal/kubeconfig"
+	"github.com/opalbolt/envoke/internal/providers"
+	"gopkg.in/yaml.v3"
+)
+
+// templateFormat is the extension point for config template formats.
+// Register new formats in formatRegistry below.
+// Currently only YAML is supported; TOML (#21) and JSON (#22) are planned.
+type templateFormat interface {
+	// Parse deserialises raw bytes into a generic document tree.
+	Parse(data []byte) (interface{}, error)
+	// Marshal serialises a resolved document tree back to bytes.
+	Marshal(v interface{}) ([]byte, error)
+}
+
+// formatRegistry maps lowercase file extensions to their templateFormat handler.
+// Add entries here to support new formats (e.g. ".toml", ".json").
+var formatRegistry = map[string]templateFormat{
+	".yaml": &yamlFormat{},
+	".yml":  &yamlFormat{},
+}
+
+// formatForPath returns the templateFormat for the given file path based on its
+// extension. Returns an error for unsupported extensions.
+func formatForPath(path string) (templateFormat, error) {
+	ext := strings.ToLower(filepath.Ext(path))
+	f, ok := formatRegistry[ext]
+	if !ok {
+		return nil, fmt.Errorf("config: unsupported template format %q (file: %s)", ext, path)
+	}
+	return f, nil
+}
+
+// yamlFormat implements templateFormat for YAML files.
+//
+// Note: YAML anchors and aliases are expanded by gopkg.in/yaml.v3 during
+// unmarshal. A secret ref under an anchor is resolved once; all aliases see
+// the resolved value. This is a known constraint — document anchor-based
+// secret refs with care.
+type yamlFormat struct{}
+
+func (f *yamlFormat) Parse(data []byte) (interface{}, error) {
+	var doc interface{}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("config: parsing YAML: %w", err)
+	}
+	return doc, nil
+}
+
+func (f *yamlFormat) Marshal(v interface{}) ([]byte, error) {
+	return yaml.Marshal(v)
+}
+
+// RenderConfigTemplate resolves all secret refs in a YAML config template file,
+// writes the result to a chmod-600 tmpfile in /dev/shm (falling back to /tmp),
+// and returns the tmpfile path.
+//
+// The tmpfile is prefixed "envoke-render-" and is removed by
+// kubeconfig.ClearRendered() on EXIT, screen lock, and sleep.
+//
+// Errors are returned immediately — a missing template file or an
+// unresolvable secret ref aborts the entire resolve.
+//
+// Note: YAML anchors and aliases are expanded by yaml.v3 during unmarshal.
+// A secret ref under an anchor is resolved once; all aliases see the resolved value.
+func RenderConfigTemplate(templatePath string, reg *providers.Registry) (string, error) {
+	slog.Debug("rendering config template", "path", templatePath)
+
+	data, err := os.ReadFile(templatePath)
+	if err != nil {
+		return "", fmt.Errorf("config: reading template %s: %w", templatePath, err)
+	}
+
+	format, err := formatForPath(templatePath)
+	if err != nil {
+		return "", err
+	}
+
+	doc, err := format.Parse(data)
+	if err != nil {
+		return "", err
+	}
+
+	resolved, err := walkAndResolve(doc, reg)
+	if err != nil {
+		return "", fmt.Errorf("config: resolving secrets in %s: %w", templatePath, err)
+	}
+
+	out, err := format.Marshal(resolved)
+	if err != nil {
+		return "", fmt.Errorf("config: marshalling %s: %w", templatePath, err)
+	}
+
+	f, err := kubeconfig.NewTempFile("envoke-render")
+	if err != nil {
+		return "", fmt.Errorf("config: creating tmpfile: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write(out); err != nil {
+		os.Remove(f.Name())
+		return "", fmt.Errorf("config: writing tmpfile: %w", err)
+	}
+
+	slog.Debug("rendered config template", "template", templatePath, "tmpfile", f.Name())
+	return f.Name(), nil
+}

--- a/internal/kubeconfig/tmpfile.go
+++ b/internal/kubeconfig/tmpfile.go
@@ -60,6 +60,20 @@ func ClearManaged() {
 	}
 }
 
+// ClearRendered removes all envoke-render config tmpfiles from the secure directory.
+// Only files with the "envoke-render-" prefix are removed.
+func ClearRendered() {
+	dir := securedir.Dir()
+	matches, err := filepath.Glob(filepath.Join(dir, "envoke-render-*.tmp"))
+	if err != nil {
+		return
+	}
+	for _, path := range matches {
+		slog.Debug("cleanup: removing rendered config tmpfile", "path", path)
+		os.Remove(path)
+	}
+}
+
 // trackedNamesPath returns the path of the tracked kctx store names file for uid.
 func trackedNamesPath(uid string) string {
 	return filepath.Join(securedir.Dir(), "kctx-"+uid+"-tracked")

--- a/internal/providers/config_provider.go
+++ b/internal/providers/config_provider.go
@@ -1,0 +1,79 @@
+package providers
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// RenderFunc is the signature of the function used to render a config template.
+// It is injected at construction time to avoid an import cycle between
+// internal/providers and internal/env.
+type RenderFunc func(templatePath string, reg *Registry) (string, error)
+
+// ConfigProvider resolves config:// URIs by rendering a YAML template file
+// with all bw:// and vault:// leaf values resolved through the registry,
+// writing the result to a secure tmpfile, and returning the tmpfile path.
+//
+// Two-step init is required to avoid a circular dependency:
+//
+//	cp := NewConfigProvider(dotenvDir, env.RenderConfigTemplate)
+//	reg.Register(cp)
+//	cp.SetRegistry(reg)
+type ConfigProvider struct {
+	// DotenvDir is the directory of the .env file, used to resolve relative
+	// template paths in config:// URIs.
+	DotenvDir string
+	reg       *Registry
+	render    RenderFunc
+}
+
+// NewConfigProvider creates a ConfigProvider for the given .env directory.
+// render is typically env.RenderConfigTemplate, injected here to avoid an
+// import cycle between internal/providers and internal/env.
+// Call SetRegistry after registering with the Registry.
+func NewConfigProvider(dotenvDir string, render RenderFunc) *ConfigProvider {
+	return &ConfigProvider{DotenvDir: dotenvDir, render: render}
+}
+
+// SetRegistry wires the back-reference needed to resolve nested secret refs
+// inside the rendered template. Must be called after Register.
+func (p *ConfigProvider) SetRegistry(reg *Registry) {
+	p.reg = reg
+}
+
+// Schemes returns the URI schemes handled by this provider.
+func (p *ConfigProvider) Schemes() []string {
+	return []string{"config"}
+}
+
+// Resolve renders a YAML config template and returns the path to the rendered
+// tmpfile. The URI must be of the form "config://relative/path/to/template.yaml".
+func (p *ConfigProvider) Resolve(uri string) (string, error) {
+	const prefix = "config://"
+	if !strings.HasPrefix(uri, prefix) {
+		return "", fmt.Errorf("config provider: unexpected URI %q", uri)
+	}
+	rel := strings.TrimPrefix(uri, prefix)
+	if rel == "" {
+		return "", fmt.Errorf("config provider: empty path in URI %q", uri)
+	}
+
+	dotenvDir := p.DotenvDir
+	if dotenvDir == "" {
+		dotenvDir = "."
+	}
+
+	if p.reg == nil {
+		return "", fmt.Errorf("config provider: SetRegistry not called — two-step init required")
+	}
+	// templatePath may escape dotenvDir via ../. This is intentional: the .env
+	// file is user-authored and trusted, same as any bw:// or vault:// reference.
+	templatePath := filepath.Join(dotenvDir, rel)
+	return p.render(templatePath, p.reg)
+}
+
+// Close is a no-op; ConfigProvider holds no resources.
+func (p *ConfigProvider) Close() error {
+	return nil
+}


### PR DESCRIPTION
Closes #20

## Problem

Projects increasingly use structured YAML config files that mix plain config with secret leaf values. Before this change, envoke had no way to handle this pattern — you either committed secrets into the config file or wrote per-language secret-loading boilerplate in every script that needed them.

## Changes

- **`internal/providers/config_provider.go`** (new) — `ConfigProvider` satisfying the `Provider` interface. `RenderFunc` is injected at construction to avoid an import cycle between `internal/providers` and `internal/env`. Includes a nil-registry guard and a code comment on the path traversal posture (user-authored `.env` files are trusted, same as `bw://` refs).
- **`internal/env/render.go`** (new) — pluggable `templateFormat` interface with `yamlFormat` implementation; `formatRegistry` keyed on file extension for future TOML (#21) and JSON (#22) support. `RenderConfigTemplate` composes existing `walkAndResolve` + `NewTempFile` — no new secret or tmpfile machinery.
- **`internal/kubeconfig/tmpfile.go`** — `ClearRendered()` added, mirrors `ClearManaged()`, globs `envoke-render-*.tmp`.
- **`cmd/envoke/main.go`** — `ConfigProvider` registered in `resolve` and `exec` commands (the two commands that process `.env` files); `ClearRendered()` called in `clear-cache`, watcher lock hook, and watcher sleep hook.

## Why

`config://` is registered as a proper `Provider` in the existing `Registry`, so `ResolveDotEnv` picks it up automatically — no changes to the resolution pipeline. The import cycle (`internal/env` already imports `internal/providers`) is broken cleanly by injecting the render function as a `RenderFunc` at the call site in `main.go`, which already imports both packages.

The `templateFormat` interface is thin on purpose — YAML is the only format in scope for this issue, but TOML (#21) and JSON (#22) plug in by adding one entry to `formatRegistry`.

Tmpfile lifecycle matches kubeconfigs exactly: `/dev/shm` first, `/tmp` fallback, `chmod 600`, `envoke-render-` prefix, wiped on EXIT / screen lock / sleep.

## How to verify

1. Create `human-test/config.yaml.template` with `bw://` or `vault://` leaf values (a demo file is included in `human-test/` but is gitignored)
2. Add to `human-test/.env`:
   ```dotenv
   JIRA_CONFIG=config://config.yaml.template
   ```
3. Run:
   ```bash
   eval "$(envoke resolve human-test/.env)"
   echo $JIRA_CONFIG          # → /dev/shm/envoke-render-xxxxxx.tmp
   cat $JIRA_CONFIG           # → rendered YAML with secrets substituted
   envoke clear-cache         # → removes the tmpfile
   ```
4. Confirm non-`bw://`/`vault://` values pass through unchanged in the rendered output
5. Confirm a missing template path produces a clear error: `config: reading template ...: no such file`
6. Confirm `envoke resolve` with a `.env` containing only plain `KEY=value` entries is unaffected