### PR TITLE
feat(ctx): generic context/file injection via CTX_ groups, deprecate kctx (#23)

### DIFF
--- a/cmd/envoke/main.go
+++ b/cmd/envoke/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/opalbolt/envoke/internal/cleanup"
 	"github.com/opalbolt/envoke/internal/config"
 	"github.com/opalbolt/envoke/internal/env"
+	"github.com/opalbolt/envoke/internal/ctx"
 	"github.com/opalbolt/envoke/internal/kubeconfig"
 	"github.com/opalbolt/envoke/internal/logger"
 	"github.com/opalbolt/envoke/internal/providers"
@@ -153,21 +154,19 @@ The output must be evaluated by your shell:
 				return fmt.Errorf("parsing %s: %w", file, err)
 			}
 
-			var kctxEntries []env.RawEntry
+			var ctxEntries []env.RawEntry
 			var envEntries []env.RawEntry
 			for _, e := range rawEntries {
-				if isKctxDirective(e) {
-					kctxEntries = append(kctxEntries, e)
-				} else {
+				switch {
+				case ctx.IsKCTXDirective(e.Key):
+					return ctx.MigrationError(e.Key, e.Value)
+				case ctx.IsCTXDirective(e.Key):
+					ctxEntries = append(ctxEntries, e)
+				default:
 					envEntries = append(envEntries, e)
 				}
 			}
 
-			for _, e := range kctxEntries {
-				if err := kubeconfig.ValidateStoreName(kctxNameFromKey(e.Key)); err != nil {
-					return fmt.Errorf("invalid kctx directive %q: %w", e.Key, err)
-				}
-			}
 
 			sharedReg := newRegistry(cfg)
 			defer sharedReg.Close() //nolint:errcheck // best-effort session cleanup
@@ -176,36 +175,80 @@ The output must be evaluated by your shell:
 			sharedReg.Register(cp)
 			cp.SetRegistry(sharedReg)
 
-			var kctxPanelEntries []ui.PanelEntry
-			var kubeconfigPath string
-			if len(kctxEntries) > 0 {
-				uid := fmt.Sprintf("%d", os.Getuid())
-				store := kubeconfig.NewNamedStore()
-				var kctxNames []string
-				var lastKubeconfigName string
-				for _, e := range kctxEntries {
-					name := kctxNameFromKey(e.Key)
-					if err := fetchKubeconfigForDirective(sharedReg, name, e.Value, uid, store); err != nil {
-						if errors.Is(err, bw.ErrInvalidPassword) {
-							return err
-						}
-						return fmt.Errorf("loading kubeconfig %q (%s): %w", name, e.Value, err)
-					}
-					lastKubeconfigName = name
-					kctxNames = append(kctxNames, name)
-					kctxPanelEntries = append(kctxPanelEntries, ui.PanelEntry{
-						Key:    name,
-						Source: e.Value,
-					})
-					slog.Debug("loaded kubeconfig into store", "name", name, "source", e.Value)
-				}
-				_ = kubeconfig.SaveTrackedNames(uid, kctxNames)
-
-				if lastKubeconfigName != "" {
-					kubeconfigPath = store.Path(uid, lastKubeconfigName)
-					slog.Debug("set KUBECONFIG", "path", kubeconfigPath)
+			
+			// ── CTX_ group processing ────────────────────────────────────────────────
+			// uid is shared across CTX_, kctx, and var-tracking blocks below.
+			uid := fmt.Sprintf("%d", os.Getuid())
+			var ctxPanelEntries []ui.PanelEntry
+			ctxGroupsState := ctx.GroupsState{Groups: make(map[string][]ctx.ContextEntry)}
+			// createdTmpfiles tracks CTX tmpfiles so we can clean up on error.
+			var createdTmpfiles []string
+			cleanupCTXTmpfiles := func() {
+				for _, p := range createdTmpfiles {
+					_ = os.Remove(p)
 				}
 			}
+
+			if len(ctxEntries) > 0 {
+				for _, e := range ctxEntries {
+					entry, err := ctx.ParseContextEntry(e.Key, e.Value)
+					if err != nil {
+						return err
+					}
+					
+					val, err := sharedReg.Resolve(entry.SourceURI)
+					if err != nil {
+						if errors.Is(err, bw.ErrInvalidPassword) {
+							cleanupCTXTmpfiles()
+							return err
+						}
+						cleanupCTXTmpfiles()
+						return fmt.Errorf("resolving %s (%s): %w", e.Key, entry.SourceURI, err)
+					}
+					
+					content := []byte(val)
+					if err := ctx.ValidateContent(entry.EnvVar, content); err != nil {
+						cleanupCTXTmpfiles()
+						return fmt.Errorf("%s: %w", e.Key, err)
+					}
+					
+					tmpf, err := kubeconfig.NewTempFile("envoke-ctx")
+					if err != nil {
+						cleanupCTXTmpfiles()
+						return fmt.Errorf("creating tmpfile for %s: %w", e.Key, err)
+					}
+					createdTmpfiles = append(createdTmpfiles, tmpf.Name())
+					if _, err := tmpf.Write(content); err != nil {
+						tmpf.Close()
+						cleanupCTXTmpfiles()
+						return fmt.Errorf("writing tmpfile for %s: %w", e.Key, err)
+					}
+					if err := tmpf.Close(); err != nil {
+						cleanupCTXTmpfiles()
+						return fmt.Errorf("closing tmpfile for %s: %w", e.Key, err)
+					}
+					entry.TmpfilePath = tmpf.Name()
+					
+					ctxGroupsState.Groups[entry.Group] = append(ctxGroupsState.Groups[entry.Group], entry)
+					ctxPanelEntries = append(ctxPanelEntries, ui.PanelEntry{
+						Key:    entry.Group + ":" + entry.EnvVar,
+						Source: entry.SourceURI,
+					})
+					slog.Debug("ctx entry resolved", "group", entry.Group, "envVar", entry.EnvVar, "tmpfile", entry.TmpfilePath)
+				}
+				
+				if err := ctx.SaveState(uid, ctxGroupsState); err != nil {
+					slog.Warn("saving ctx state", "err", err)
+				}
+				
+				// Emit META exports as always-on baseline.
+				if metaEntries, ok := ctxGroupsState.Groups["meta"]; ok {
+					for _, entry := range metaEntries {
+						fmt.Fprintf(os.Stdout, "export %s=%s\n", entry.EnvVar, entry.TmpfilePath)
+					}
+				}
+			}
+			var kubeconfigPath string
 
 			var resolvedEntries []env.EnvEntry
 			if len(envEntries) > 0 {
@@ -232,7 +275,7 @@ The output must be evaluated by your shell:
 			}
 
 			if len(resolvedEntries) > 0 {
-				uid := fmt.Sprintf("%d", os.Getuid())
+				// uid already declared above
 				names := make([]string, len(resolvedEntries))
 				for i, e := range resolvedEntries {
 					names[i] = e.Key
@@ -240,17 +283,14 @@ The output must be evaluated by your shell:
 				_ = state.SaveVarNames(uid, names)
 			}
 
-			panelEntries := make([]ui.PanelEntry, 0, len(resolvedEntries)+len(kctxPanelEntries))
+			panelEntries := make([]ui.PanelEntry, 0, len(resolvedEntries)+len(ctxPanelEntries))
 			for _, e := range resolvedEntries {
 				panelEntries = append(panelEntries, ui.PanelEntry{Key: e.Key, Source: e.Source})
 			}
-			for _, e := range kctxPanelEntries {
-				panelEntries = append(panelEntries, ui.PanelEntry{
-					Key:    "kctx:" + e.Key,
-					Source: e.Source,
-				})
+			for _, e := range ctxPanelEntries {
+				panelEntries = append(panelEntries, e)
 			}
-			totalCount := len(resolvedEntries) + len(kctxPanelEntries)
+			totalCount := len(resolvedEntries) + len(ctxPanelEntries)
 			headline := fmt.Sprintf("Loaded %s from %s",
 				ui.Bold(os.Stderr, pluralItems(totalCount)),
 				ui.Bold(os.Stderr, file))
@@ -264,7 +304,7 @@ The output must be evaluated by your shell:
 				case "fish":
 					fmt.Println("# Fish shell trap not supported via eval; use envoke clear-cache manually")
 				default:
-					if kubeconfigPath != "" {
+					if kubeconfigPath != "" || len(ctxEntries) > 0 {
 						fmt.Println("trap 'eval \"$(envoke unload 2>/dev/null)\" 2>/dev/null; envoke clear-cache 2>/dev/null' EXIT")
 					} else {
 						fmt.Println("trap 'envoke clear-cache' EXIT")
@@ -280,29 +320,6 @@ The output must be evaluated by your shell:
 	return cmd
 }
 
-// isKctxDirective returns true if the entry is a KCTX_<name>=bw:// directive.
-func isKctxDirective(e env.RawEntry) bool {
-	if !strings.HasPrefix(e.Key, "KCTX_") {
-		return false
-	}
-	return strings.HasPrefix(e.Value, "bw://")
-}
-
-// kctxNameFromKey derives a kubeconfig store name from a KCTX_ key.
-// KCTX_PROD → "prod", KCTX_MY_CLUSTER → "my_cluster"
-func kctxNameFromKey(key string) string {
-	return strings.ToLower(strings.TrimPrefix(key, "KCTX_"))
-}
-
-// fetchKubeconfigForDirective fetches a kubeconfig from a bw:// source and stores it.
-func fetchKubeconfigForDirective(reg *providers.Registry, name, source, uid string, store *kubeconfig.NamedStore) error {
-	uri := normalizeKubeconfigURI(source)
-	val, err := reg.Resolve(uri)
-	if err != nil {
-		return err
-	}
-	return store.Put(uid, name, []byte(val))
-}
 
 // writeTempEnv writes env entries to a temp .env file for processing by ResolveDotEnv.
 func writeTempEnv(entries []env.RawEntry) (string, error) {
@@ -435,32 +452,14 @@ Examples:
   envoke load prod bw://kubernetes/prod`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			name := args[0]
-			source := args[1]
-
-			if err := kubeconfig.ValidateStoreName(name); err != nil {
-				return err
-			}
-
-			slog.Debug("loading kubeconfig", "name", name, "source", source)
-
-			uid := fmt.Sprintf("%d", os.Getuid())
-			store := kubeconfig.NewNamedStore()
-			reg := newRegistry(cfg)
-			defer reg.Close() //nolint:errcheck // best-effort session cleanup
-
-			uri := normalizeKubeconfigURI(source)
-			val, err := reg.Resolve(uri)
-			if err != nil {
-				return err
-			}
-
-			if err := store.Put(uid, name, []byte(val)); err != nil {
-				return fmt.Errorf("storing kubeconfig %q: %w", name, err)
-			}
-
-			ui.Success(os.Stderr, fmt.Sprintf("Loaded kubeconfig: %s", ui.Bold(os.Stderr, name)))
-			return nil
+			fmt.Fprintln(os.Stderr, "envoke load is deprecated and has been removed.")
+			fmt.Fprintln(os.Stderr, "")
+			fmt.Fprintln(os.Stderr, "Use CTX_<GROUP>=<uri>#<ENVVAR> entries in your .env file instead:")
+			fmt.Fprintln(os.Stderr, "")
+			fmt.Fprintln(os.Stderr, "  CTX_PROD=bw://kubernetes/prod#KUBECONFIG")
+			fmt.Fprintln(os.Stderr, "")
+			fmt.Fprintln(os.Stderr, `Then run: eval "$(envoke resolve .env)"`)
+			return fmt.Errorf("deprecated: use CTX_ directives and envoke resolve")
 		},
 	}
 }
@@ -469,73 +468,87 @@ Examples:
 
 func switchCmd(cfg *config.Config) *cobra.Command {
 	return &cobra.Command{
-		Use:   "switch <name> [bw://item]",
-		Short: "Switch to a named kubeconfig (or fetch one if a source is given)",
-		Long: `Switch KUBECONFIG to a named kubeconfig previously loaded with 'envoke load'.
+		Use:   "switch <group>",
+		Short: "Switch to a context group (instant, no provider calls)",
+		Long: `Switch all context env vars to a named group previously loaded by 'envoke resolve'.
 
-If the named kubeconfig is not in the local store, a source (bw://) may be
-provided to fetch it on the fly.
+No provider calls are made — all secrets were fetched eagerly by resolve and
+written to tmpfiles in /dev/shm. Switch is purely local.
+
+The META group (CTX_META) is re-applied as a persistent baseline on every switch.
+'envoke switch meta' is rejected — META is always active.
 
 Examples:
-  envoke switch prod                          # use pre-loaded 'prod'
-  envoke switch staging bw://k8s/staging      # fetch directly if not pre-loaded`,
-		Args: cobra.RangeArgs(1, 2),
+  envoke switch prod
+  envoke switch staging`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			name := args[0]
-			source := ""
-			if len(args) > 1 {
-				source = args[1]
+			name := strings.ToLower(args[0])
+
+			if name == "meta" {
+				return fmt.Errorf("'meta' is not a switchable group — META is always applied as a baseline on every switch")
 			}
-			slog.Debug("switching kubeconfig", "name", name, "source", source)
 
 			uid := fmt.Sprintf("%d", os.Getuid())
-			store := kubeconfig.NewNamedStore()
+			st, err := ctx.LoadState(uid)
+			if err != nil {
+				return fmt.Errorf("loading ctx state: %w", err)
+			}
+			if len(st.Groups) == 0 {
+				return fmt.Errorf("no context groups loaded\n\nRun: eval \"$(envoke resolve .env)\"")
+			}
 
-			var kubeconfigData []byte
-
-			if err := kubeconfig.ValidateStoreName(name); err == nil {
-				data, err := store.Get(uid, name)
-				if err != nil {
-					return fmt.Errorf("reading named kubeconfig %q: %w", name, err)
+			targetEntries, ok := st.Groups[name]
+			if !ok {
+				available := make([]string, 0, len(st.Groups))
+				for g := range st.Groups {
+					if g != "meta" {
+						available = append(available, g)
+					}
 				}
-				if data != nil {
-					kubeconfigData = data
+				sort.Strings(available)
+				return fmt.Errorf("group %q not found in loaded state\n\nAvailable groups: %s", name, strings.Join(available, ", "))
+			}
+
+			// Unload currently active group env vars (not META).
+			if st.ActiveGroup != "" && st.ActiveGroup != name {
+				for _, e := range st.Groups[st.ActiveGroup] {
+					fmt.Fprintf(os.Stdout, "unset %s\n", e.EnvVar)
 				}
 			}
 
-			if kubeconfigData == nil {
-				if source == "" {
-					return fmt.Errorf(
-						"no pre-loaded kubeconfig named %q found\n"+
-							"Run: envoke load %s <bw://item>",
-						name, name,
-					)
-				}
-				reg := newRegistry(cfg)
-				defer reg.Close() //nolint:errcheck // best-effort session cleanup
-				uri := normalizeKubeconfigURI(source)
-				val, err := reg.Resolve(uri)
-				if err != nil {
-					return fmt.Errorf("fetching kubeconfig for %q: %w", name, err)
-				}
-				kubeconfigData = []byte(val)
-				if err := store.Put(uid, name, kubeconfigData); err != nil {
-					return fmt.Errorf("caching kubeconfig %q: %w", name, err)
-				}
+			// Re-apply META baseline.
+			for _, e := range st.Groups["meta"] {
+				fmt.Fprintf(os.Stdout, "export %s=%s\n", e.EnvVar, e.TmpfilePath)
 			}
 
-			path := store.Path(uid, name)
-
-			fmt.Printf("export KUBECONFIG=%s\n", path)
-			fmt.Printf("trap 'eval \"$(envoke unload 2>/dev/null)\"' EXIT\n")
-
-			srcLabel := switchSourceLabel(name, source)
-			panelEntries := []ui.PanelEntry{
-				{Key: "KUBECONFIG", Value: path, Source: srcLabel},
+			// Build META env var set for collision detection.
+			metaEnvVars := make(map[string]bool)
+			for _, e := range st.Groups["meta"] {
+				metaEnvVars[e.EnvVar] = true
 			}
-			if ctx := currentKubectlContext(path); ctx != "" {
-				panelEntries = append(panelEntries, ui.PanelEntry{Key: "Context", Value: ctx})
+
+			// Apply target group — warn loudly on META collision, group wins.
+			var panelEntries []ui.PanelEntry
+			for _, e := range targetEntries {
+				if metaEnvVars[e.EnvVar] {
+					fmt.Fprintf(os.Stderr, "\u26a0  envoke: %s defined in both meta and %s — %s wins\n", e.EnvVar, name, name)
+				}
+				fmt.Fprintf(os.Stdout, "export %s=%s\n", e.EnvVar, e.TmpfilePath)
+				panelEntries = append(panelEntries, ui.PanelEntry{
+					Key:   e.EnvVar,
+					Value: e.TmpfilePath,
+				})
 			}
+
+			fmt.Fprintf(os.Stdout, "trap 'eval \"$(envoke unload 2>/dev/null)\"' EXIT\n")
+
+			// Persist active group for status/unload.
+			st.ActiveGroup = name
+			if err := ctx.SaveState(uid, st); err != nil {
+				slog.Warn("saving active group", "err", err)
+			}
+
 			headline := fmt.Sprintf("Switched to %s", ui.Bold(os.Stderr, name))
 			ui.Panel(os.Stderr, "envoke", headline, panelEntries, cfg.UI.Border)
 			return nil
@@ -543,12 +556,6 @@ Examples:
 	}
 }
 
-func switchSourceLabel(name, source string) string {
-	if source == "" {
-		return "named store"
-	}
-	return source
-}
 
 func currentKubectlContext(kubeconfigPath string) string {
 	cmd := exec.Command("kubectl", "config", "current-context")
@@ -616,6 +623,43 @@ func statusCmd() *cobra.Command {
 				sort.Strings(storedNames)
 				ui.Header(w, "Loaded kubeconfigs (use 'envoke switch <name>')")
 				ui.List(w, storedNames)
+			}
+			// ── CTX groups section ────────────────────────────────────────────
+			ctxSt, ctxErr := ctx.LoadState(uid)
+			if ctxErr == nil && len(ctxSt.Groups) > 0 {
+				fmt.Fprintln(w)
+				ui.Header(w, "Context groups (CTX_)")
+				// META first
+				if metaEntries, ok := ctxSt.Groups["meta"]; ok {
+					fmt.Fprintf(w, "  ◆ meta  %s\n", ui.Gray(w, "(persistent baseline)"))
+					for _, e := range metaEntries {
+						fmt.Fprintf(w, "      %-30s %s\n", e.EnvVar, ui.Gray(w, e.TmpfilePath))
+					}
+				}
+				// Active group
+				if ctxSt.ActiveGroup != "" {
+					if entries, ok := ctxSt.Groups[ctxSt.ActiveGroup]; ok {
+						fmt.Fprintf(w, "  ● %s  %s\n", ctxSt.ActiveGroup, ui.Green(w, "(active group)"))
+						for _, e := range entries {
+							fmt.Fprintf(w, "      %-30s %s\n", e.EnvVar, e.TmpfilePath)
+						}
+					}
+				}
+				// Inactive groups
+				groupNames := make([]string, 0, len(ctxSt.Groups))
+				for g := range ctxSt.Groups {
+					if g != "meta" && g != ctxSt.ActiveGroup {
+						groupNames = append(groupNames, g)
+					}
+				}
+				sort.Strings(groupNames)
+				for _, g := range groupNames {
+					entries := ctxSt.Groups[g]
+					fmt.Fprintf(w, "  ○ %s  %s\n", g, ui.Gray(w, "(inactive, loaded)"))
+					for _, e := range entries {
+						fmt.Fprintf(w, "      %-30s %s\n", e.EnvVar, ui.Gray(w, e.TmpfilePath))
+					}
+				}
 			}
 			return nil
 		},
@@ -692,6 +736,28 @@ When using the envoke shell-init, the shell function handles this automatically.
 				}
 				_ = kubeconfig.ClearTrackedNames(uid)
 			}
+			// ── CTX group cleanup ────────────────────────────────────────────
+			ctxSt, ctxErr := ctx.LoadState(uid)
+			if ctxErr == nil && len(ctxSt.Groups) > 0 {
+				for grp, entries := range ctxSt.Groups {
+					for _, e := range entries {
+						fmt.Fprintf(os.Stdout, "unset %s\n", e.EnvVar)
+						if e.TmpfilePath != "" {
+							if rmErr := os.Remove(e.TmpfilePath); rmErr != nil && !os.IsNotExist(rmErr) {
+								slog.Warn("removing ctx tmpfile", "path", e.TmpfilePath, "err", rmErr)
+							}
+						}
+						panelEntries = append(panelEntries, ui.PanelEntry{
+							Key:   "ctx:" + grp + ":" + e.EnvVar,
+							Value: e.TmpfilePath,
+						})
+					}
+				}
+				if err := ctx.ClearState(uid); err != nil {
+					slog.Warn("clearing ctx state", "err", err)
+				}
+			}
+
 
 			if len(panelEntries) == 0 {
 				ui.Warn(os.Stderr, "Nothing to unload")

--- a/cmd/envoke/main.go
+++ b/cmd/envoke/main.go
@@ -156,12 +156,15 @@ The output must be evaluated by your shell:
 
 			var ctxEntries []env.RawEntry
 			var envEntries []env.RawEntry
+			var defaultGroup string
 			for _, e := range rawEntries {
 				switch {
 				case ctx.IsKCTXDirective(e.Key):
 					return ctx.MigrationError(e.Key, e.Value)
 				case ctx.IsCTXDirective(e.Key):
 					ctxEntries = append(ctxEntries, e)
+				case e.Key == "ENVOKE_DEFAULT_GROUP":
+					defaultGroup = strings.ToLower(e.Value) // consumed, not exported
 				default:
 					envEntries = append(envEntries, e)
 				}
@@ -247,6 +250,32 @@ The output must be evaluated by your shell:
 						fmt.Fprintf(os.Stdout, "export %s=%s\n", entry.EnvVar, entry.TmpfilePath)
 					}
 				}
+				
+				// Auto-apply ENVOKE_DEFAULT_GROUP if specified and the group was loaded.
+				if defaultGroup != "" {
+					if groupEntries, ok := ctxGroupsState.Groups[defaultGroup]; ok {
+						metaEnvVars := make(map[string]bool)
+						for _, e := range ctxGroupsState.Groups["meta"] {
+							metaEnvVars[e.EnvVar] = true
+						}
+						for _, e := range groupEntries {
+							if metaEnvVars[e.EnvVar] {
+								fmt.Fprintf(os.Stderr, "⚠  envoke: %s defined in both meta and %s — %s wins\n", e.EnvVar, defaultGroup, defaultGroup)
+							}
+							fmt.Fprintf(os.Stdout, "export %s=%s\n", e.EnvVar, e.TmpfilePath)
+						}
+						ctxGroupsState.ActiveGroup = defaultGroup
+						if err := ctx.SaveState(uid, ctxGroupsState); err != nil {
+							slog.Warn("saving active group after default", "err", err)
+						}
+						slog.Debug("applied default group", "group", defaultGroup)
+					} else {
+						fmt.Fprintf(os.Stderr, "⚠  envoke: ENVOKE_DEFAULT_GROUP=%q is not a loaded group — ignored\n", defaultGroup)
+					}
+				}
+			}
+			if defaultGroup != "" && len(ctxEntries) == 0 {
+				fmt.Fprintf(os.Stderr, "⚠  envoke: ENVOKE_DEFAULT_GROUP=%q set but no CTX_ groups were loaded\n", defaultGroup)
 			}
 			var kubeconfigPath string
 
@@ -580,7 +609,7 @@ func currentKubectlContext(kubeconfigPath string) string {
 func statusCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
-		Short: "Show loaded env vars, KUBECONFIG, and named kubeconfigs",
+		Short: "Show loaded env vars and context groups",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := os.Stdout
 			uid := fmt.Sprintf("%d", os.Getuid())
@@ -598,53 +627,40 @@ func statusCmd() *cobra.Command {
 			}
 			fmt.Fprintln(w)
 
-			ui.Header(w, "Kubeconfig")
-			kc := os.Getenv("KUBECONFIG")
-			if kc == "" {
-				ui.Item(w, "KUBECONFIG", ui.Gray(w, "not set"))
-				ui.Item(w, "Managed by envoke", ui.Gray(w, "no"))
-			} else {
-				ui.Item(w, "KUBECONFIG", ui.Green(w, kc))
-				if kubeconfig.IsManaged(kc) {
-					ui.Item(w, "Managed by envoke", ui.Green(w, "yes"))
-				} else {
-					ui.Item(w, "Managed by envoke", ui.Yellow(w, "no (external)"))
-				}
-				if ctx := currentKubectlContext(kc); ctx != "" {
-					ui.Item(w, "Current context", ui.Bold(w, ctx))
-				}
-			}
-
-			store := kubeconfig.NewNamedStore()
-			storedNames, err := store.List(uid)
-			if err != nil {
-				slog.Warn("listing named kubeconfigs", "err", err)
-			} else if len(storedNames) > 0 {
-				sort.Strings(storedNames)
-				ui.Header(w, "Loaded kubeconfigs (use 'envoke switch <name>')")
-				ui.List(w, storedNames)
-			}
 			// ── CTX groups section ────────────────────────────────────────────
 			ctxSt, ctxErr := ctx.LoadState(uid)
 			if ctxErr == nil && len(ctxSt.Groups) > 0 {
-				fmt.Fprintln(w)
 				ui.Header(w, "Context groups (CTX_)")
+
 				// META first
 				if metaEntries, ok := ctxSt.Groups["meta"]; ok {
 					fmt.Fprintf(w, "  ◆ meta  %s\n", ui.Gray(w, "(persistent baseline)"))
 					for _, e := range metaEntries {
-						fmt.Fprintf(w, "      %-30s %s\n", e.EnvVar, ui.Gray(w, e.TmpfilePath))
+						fmt.Fprintf(w, "      %-32s %s\n", e.EnvVar, ui.Gray(w, e.TmpfilePath))
 					}
 				}
+
+				// renderGroup prints one group's entries, with extra detail for known types.
+				renderGroup := func(entries []ctx.ContextEntry) {
+					for _, e := range entries {
+						detail := ""
+						if e.EnvVar == "KUBECONFIG" {
+							if ktx := currentKubectlContext(e.TmpfilePath); ktx != "" {
+								detail = "  " + ui.Gray(w, "(→ "+ktx+")")
+							}
+						}
+						fmt.Fprintf(w, "      %-32s %s%s\n", e.EnvVar, e.TmpfilePath, detail)
+					}
+				}
+
 				// Active group
 				if ctxSt.ActiveGroup != "" {
 					if entries, ok := ctxSt.Groups[ctxSt.ActiveGroup]; ok {
-						fmt.Fprintf(w, "  ● %s  %s\n", ctxSt.ActiveGroup, ui.Green(w, "(active group)"))
-						for _, e := range entries {
-							fmt.Fprintf(w, "      %-30s %s\n", e.EnvVar, e.TmpfilePath)
-						}
+						fmt.Fprintf(w, "  ● %s  %s\n", ctxSt.ActiveGroup, ui.Green(w, "(active)"))
+						renderGroup(entries)
 					}
 				}
+
 				// Inactive groups
 				groupNames := make([]string, 0, len(ctxSt.Groups))
 				for g := range ctxSt.Groups {
@@ -654,11 +670,8 @@ func statusCmd() *cobra.Command {
 				}
 				sort.Strings(groupNames)
 				for _, g := range groupNames {
-					entries := ctxSt.Groups[g]
-					fmt.Fprintf(w, "  ○ %s  %s\n", g, ui.Gray(w, "(inactive, loaded)"))
-					for _, e := range entries {
-						fmt.Fprintf(w, "      %-30s %s\n", e.EnvVar, ui.Gray(w, e.TmpfilePath))
-					}
+					fmt.Fprintf(w, "  ○ %s  %s\n", g, ui.Gray(w, "(inactive)"))
+					renderGroup(ctxSt.Groups[g])
 				}
 			}
 			return nil

--- a/cmd/envoke/main.go
+++ b/cmd/envoke/main.go
@@ -680,8 +680,8 @@ func statusCmd() *cobra.Command {
 				}
 
 				// Active variables summary: META + active group, showing source group.
-				// Only shown when a group is active.
-				if ctxSt.ActiveGroup != "" {
+				// Always show when groups are loaded — META is active immediately after resolve.
+				if len(ctxSt.Groups) > 0 {
 					fmt.Fprintln(w)
 					ui.Header(w, "Active context variables")
 					// Collect in order: META entries first, then active group (group wins on collision).
@@ -696,7 +696,9 @@ func statusCmd() *cobra.Command {
 						}
 					}
 					addEntries(ctxSt.Groups["meta"], "meta")
-					addEntries(ctxSt.Groups[ctxSt.ActiveGroup], ctxSt.ActiveGroup)
+					if ctxSt.ActiveGroup != "" {
+						addEntries(ctxSt.Groups[ctxSt.ActiveGroup], ctxSt.ActiveGroup)
+					}
 					for _, envVar := range order {
 						grp := seen[envVar]
 						var grpLabel string

--- a/cmd/envoke/main.go
+++ b/cmd/envoke/main.go
@@ -640,16 +640,10 @@ func statusCmd() *cobra.Command {
 					}
 				}
 
-				// renderGroup prints one group's entries, with extra detail for known types.
+				// renderGroup prints one group's entries (path only, no extra annotations).
 				renderGroup := func(entries []ctx.ContextEntry) {
 					for _, e := range entries {
-						detail := ""
-						if e.EnvVar == "KUBECONFIG" {
-							if ktx := currentKubectlContext(e.TmpfilePath); ktx != "" {
-								detail = "  " + ui.Gray(w, "(→ "+ktx+")")
-							}
-						}
-						fmt.Fprintf(w, "      %-32s %s%s\n", e.EnvVar, e.TmpfilePath, detail)
+						fmt.Fprintf(w, "      %-32s %s\n", e.EnvVar, e.TmpfilePath)
 					}
 				}
 
@@ -672,6 +666,36 @@ func statusCmd() *cobra.Command {
 				for _, g := range groupNames {
 					fmt.Fprintf(w, "  ○ %s  %s\n", g, ui.Gray(w, "(inactive)"))
 					renderGroup(ctxSt.Groups[g])
+				}
+
+				// Active variables summary: META + active group, showing source group.
+				// Only shown when a group is active.
+				if ctxSt.ActiveGroup != "" {
+					fmt.Fprintln(w)
+					ui.Header(w, "Active context variables")
+					// Collect in order: META entries first, then active group (group wins on collision).
+					seen := make(map[string]string) // envVar → group
+					var order []string
+					addEntries := func(entries []ctx.ContextEntry, group string) {
+						for _, e := range entries {
+							if _, exists := seen[e.EnvVar]; !exists {
+								order = append(order, e.EnvVar)
+							}
+							seen[e.EnvVar] = group
+						}
+					}
+					addEntries(ctxSt.Groups["meta"], "meta")
+					addEntries(ctxSt.Groups[ctxSt.ActiveGroup], ctxSt.ActiveGroup)
+					for _, envVar := range order {
+						grp := seen[envVar]
+						var grpLabel string
+						if grp == "meta" {
+							grpLabel = ui.Gray(w, "◆ meta")
+						} else {
+							grpLabel = ui.Green(w, "● "+grp)
+						}
+						fmt.Fprintf(w, "  %-32s %s\n", envVar, grpLabel)
+					}
 				}
 			}
 			return nil

--- a/cmd/envoke/main.go
+++ b/cmd/envoke/main.go
@@ -44,14 +44,20 @@ func rootCmd() *cobra.Command {
 
 	root := &cobra.Command{
 		Use:   "envoke",
-		Short: "Unified secret environment loader — env vars and kubeconfigs",
-		Long: `envoke (env + invoke) resolves secrets and kubeconfigs from a single .env file.
+		Short: "Resolve secrets and context files from a .env file",
+		Long: `envoke resolves secrets from Bitwarden (and other providers) and writes
+context files — kubeconfigs, credentials, tokens — to secure tmpfiles.
 
-  envoke resolve .env            # resolve both env secrets and kubeconfig refs
-  envoke switch prod             # switch KUBECONFIG to a pre-loaded named config
-  envoke shell-init              # combined shell setup
+  eval "$(envoke resolve .env)"   # resolve secrets and apply default group
+  eval "$(envoke switch prod)"    # switch to a different context group
+  envoke status                   # show what is loaded
+  envoke shell-init               # one-time shell setup
 
-The .env file supports KCTX_<name>=bw://... entries that load kubeconfigs into the local named store.`,
+Context groups let any secret file be injected via a single env var fragment:
+
+  CTX_PROD=bw://k8s/prod#KUBECONFIG
+  CTX_PROD=bw://talos/prod#TALOSCONFIG
+	  CTX_META=bw://aws/shared#AWS_SHARED_CREDENTIALS_FILE`,
 		Version:      version.String(),
 		SilenceUsage: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
@@ -121,17 +127,25 @@ func resolveCmd(cfg *config.Config) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "resolve [file]",
-		Short: "Resolve .env secrets and kubeconfig directives",
-		Long: `Resolve a .env file, handling both secret references and kubeconfig directives.
+		Short: "Resolve .env secrets and context groups",
+		Long: `Resolve a .env file, exporting secrets as shell variables and writing
+context files to secure tmpfiles in /dev/shm.
 
-Secret references (bw://) are resolved and exported as shell variables.
+Secret references (bw://) are resolved and exported:
 
-Kubeconfig directives (keys prefixed with KCTX_) load a kubeconfig into the
-local named store and automatically set KUBECONFIG to the last loaded one:
+  DB_PASSWORD=bw://myapp/db
 
-  KCTX_PROD=bw://kubernetes/prod-cluster     # loads kubeconfig named "prod"
+CTX_ entries write a secret to a tmpfile and export an env var pointing at it.
+The fragment (#ENVVAR) determines which env var to set:
 
-Use 'envoke switch <name>' to switch between loaded kubeconfigs at any time.
+  CTX_PROD=bw://k8s/prod#KUBECONFIG             # sets $KUBECONFIG
+  CTX_PROD=bw://talos/prod#TALOSCONFIG           # sets $TALOSCONFIG
+  CTX_META=bw://aws/shared#AWS_SHARED_CREDENTIALS_FILE
+
+CTX_META entries are a persistent baseline re-applied on every switch.
+Add ENVOKE_DEFAULT_GROUP to auto-switch after resolve:
+
+  ENVOKE_DEFAULT_GROUP=prod
 
 The output must be evaluated by your shell:
 
@@ -472,14 +486,15 @@ func yamlCmd(cfg *config.Config) *cobra.Command {
 
 func loadCmd(cfg *config.Config) *cobra.Command {
 	return &cobra.Command{
-		Use:   "load <name> <bw://item>",
-		Short: "Fetch a kubeconfig and cache it under a local name",
-		Long: `Fetch a kubeconfig from Bitwarden and store it in the local
-named store so that 'envoke switch <name>' can load it without re-fetching.
+		Use:   "load",
+		Short: "[deprecated] use CTX_ directives in your .env instead",
+		Long: `envoke load is deprecated and has no effect.
 
-Examples:
-  envoke load prod bw://kubernetes/prod`,
-		Args: cobra.ExactArgs(2),
+ Use CTX_<GROUP>=<uri>#<ENVVAR> entries in your .env file instead:
+
+ CTX_PROD=bw://kubernetes/prod#KUBECONFIG
+
+Then run: eval "$(envoke resolve .env)"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Fprintln(os.Stderr, "envoke load is deprecated and has been removed.")
 			fmt.Fprintln(os.Stderr, "")

--- a/cmd/envoke/main.go
+++ b/cmd/envoke/main.go
@@ -18,8 +18,8 @@ import (
 
 	"github.com/opalbolt/envoke/internal/cleanup"
 	"github.com/opalbolt/envoke/internal/config"
-	"github.com/opalbolt/envoke/internal/env"
 	"github.com/opalbolt/envoke/internal/ctx"
+	"github.com/opalbolt/envoke/internal/env"
 	"github.com/opalbolt/envoke/internal/kubeconfig"
 	"github.com/opalbolt/envoke/internal/logger"
 	"github.com/opalbolt/envoke/internal/providers"
@@ -184,7 +184,6 @@ The output must be evaluated by your shell:
 				}
 			}
 
-
 			sharedReg := newRegistry(cfg)
 			defer sharedReg.Close() //nolint:errcheck // best-effort session cleanup
 			dotenvDir := filepath.Dir(file)
@@ -192,7 +191,6 @@ The output must be evaluated by your shell:
 			sharedReg.Register(cp)
 			cp.SetRegistry(sharedReg)
 
-			
 			// ── CTX_ group processing ────────────────────────────────────────────────
 			// uid is shared across CTX_, kctx, and var-tracking blocks below.
 			uid := fmt.Sprintf("%d", os.Getuid())
@@ -212,7 +210,7 @@ The output must be evaluated by your shell:
 					if err != nil {
 						return err
 					}
-					
+
 					val, err := sharedReg.Resolve(entry.SourceURI)
 					if err != nil {
 						if errors.Is(err, bw.ErrInvalidPassword) {
@@ -222,13 +220,13 @@ The output must be evaluated by your shell:
 						cleanupCTXTmpfiles()
 						return fmt.Errorf("resolving %s (%s): %w", e.Key, entry.SourceURI, err)
 					}
-					
+
 					content := []byte(val)
 					if err := ctx.ValidateContent(entry.EnvVar, content); err != nil {
 						cleanupCTXTmpfiles()
 						return fmt.Errorf("%s: %w", e.Key, err)
 					}
-					
+
 					tmpf, err := kubeconfig.NewTempFile("envoke-ctx")
 					if err != nil {
 						cleanupCTXTmpfiles()
@@ -245,7 +243,7 @@ The output must be evaluated by your shell:
 						return fmt.Errorf("closing tmpfile for %s: %w", e.Key, err)
 					}
 					entry.TmpfilePath = tmpf.Name()
-					
+
 					ctxGroupsState.Groups[entry.Group] = append(ctxGroupsState.Groups[entry.Group], entry)
 					ctxPanelEntries = append(ctxPanelEntries, ui.PanelEntry{
 						Key:    entry.Group + ":" + entry.EnvVar,
@@ -253,18 +251,18 @@ The output must be evaluated by your shell:
 					})
 					slog.Debug("ctx entry resolved", "group", entry.Group, "envVar", entry.EnvVar, "tmpfile", entry.TmpfilePath)
 				}
-				
+
 				if err := ctx.SaveState(uid, ctxGroupsState); err != nil {
 					slog.Warn("saving ctx state", "err", err)
 				}
-				
+
 				// Emit META exports as always-on baseline.
 				if metaEntries, ok := ctxGroupsState.Groups["meta"]; ok {
 					for _, entry := range metaEntries {
 						fmt.Fprintf(os.Stdout, "export %s=%s\n", entry.EnvVar, entry.TmpfilePath)
 					}
 				}
-				
+
 				// Auto-apply ENVOKE_DEFAULT_GROUP if specified and the group was loaded.
 				if defaultGroup != "" {
 					if groupEntries, ok := ctxGroupsState.Groups[defaultGroup]; ok {
@@ -362,7 +360,6 @@ The output must be evaluated by your shell:
 	cmd.Flags().BoolVar(&force, "force", false, "Bypass terminal check and print exports to terminal anyway")
 	return cmd
 }
-
 
 // writeTempEnv writes env entries to a temp .env file for processing by ResolveDotEnv.
 func writeTempEnv(entries []env.RawEntry) (string, error) {
@@ -600,7 +597,6 @@ Examples:
 	}
 }
 
-
 func currentKubectlContext(kubeconfigPath string) string {
 	cmd := exec.Command("kubectl", "config", "current-context")
 	if kubeconfigPath != "" {
@@ -809,7 +805,6 @@ When using the envoke shell-init, the shell function handles this automatically.
 					slog.Warn("clearing ctx state", "err", err)
 				}
 			}
-
 
 			if len(panelEntries) == 0 {
 				ui.Warn(os.Stderr, "Nothing to unload")

--- a/docs/direnv.md
+++ b/docs/direnv.md
@@ -24,7 +24,7 @@ use_envoke() {
 ```
 
 `watch_file` tells direnv to re-evaluate `.envrc` whenever the `.env` file changes.
-The `envoke unload` call ensures stale variables are cleared before loading fresh ones.
+The `envoke unload` call ensures stale variables and tmpfiles are cleared before loading fresh ones.
 
 ### 2. Use it in your project `.envrc`
 
@@ -49,9 +49,17 @@ direnv allow
 
 **`.env`:**
 ```bash
-DB_HOST=postgres.internal
-DB_PASSWORD=bw://database/myapp-prod
-KCTX_PROD=bw://kubernetes/prod-cluster
+DB_PASSWORD=bw://myapp/db
+
+ENVOKE_DEFAULT_GROUP=prod
+
+CTX_META=bw://tokens/github/password#GITHUB_TOKEN
+CTX_META=bw://aws/shared#AWS_SHARED_CREDENTIALS_FILE
+
+CTX_PROD=bw://k8s/prod#KUBECONFIG
+CTX_PROD=bw://talos/prod#TALOSCONFIG
+
+CTX_STAGING=bw://k8s/staging#KUBECONFIG
 ```
 
 **`.envrc`:**
@@ -59,7 +67,13 @@ KCTX_PROD=bw://kubernetes/prod-cluster
 use envoke .env
 ```
 
-When you `cd` into the directory, direnv evaluates `.envrc`, which calls `envoke resolve .env`. Secrets are loaded and the `prod` kubeconfig is available via `envoke switch prod`. When you `cd` out, direnv unsets them automatically.
+When you `cd` into the directory, direnv evaluates `.envrc`, which calls `envoke resolve .env`. Secrets are exported, context tmpfiles are written, and the `prod` group is activated automatically (via `ENVOKE_DEFAULT_GROUP`). When you `cd` out, direnv clears them automatically.
+
+To switch groups while inside the directory:
+
+```bash
+eval "$(envoke switch staging)"
+```
 
 ## Notes
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -10,27 +10,68 @@ KEY='value with spaces'
 export KEY=value        # export prefix is accepted and stripped
 ```
 
-### Bitwarden reference format
+### Secret references
 
 ```bash
-KEY=bw://folder/item                    # password field (default)
+KEY=bw://folder/item                    # secure note body or password field
 KEY=bw://folder/item/username           # username field
-KEY=bw://folder/item/note               # notes / secure note
+KEY=bw://folder/item/note               # notes / secure note (explicit)
 KEY=bw://folder/item/totp               # TOTP code
 KEY=bw://folder/item/field:custom_name  # custom field by name
 KEY=bw://collection:name/item           # item in a named collection
 ```
 
-### Kubeconfig directives
+For login items, the default field is `password`. For secure note items with no login, the note body is returned automatically — no `/note` suffix needed.
 
-Lines prefixed with `KCTX_` load a kubeconfig into the named store rather than being exported as env vars:
+### CTX_ context groups
+
+`CTX_<GROUP>=<uri>#<ENVVAR>` entries write a secret to a tmpfile in `/dev/shm` and export `$ENVVAR` pointing at it. The fragment determines the target env var — envoke places no meaning on it beyond that:
 
 ```bash
-KCTX_PROD=bw://kubernetes/prod-cluster
-KCTX_STAGING=bw://kubernetes/staging-cluster
+CTX_PROD=bw://k8s/prod#KUBECONFIG
+CTX_PROD=bw://talos/prod#TALOSCONFIG
+CTX_PROD=bw://aws/prod#AWS_SHARED_CREDENTIALS_FILE
+CTX_META=bw://tokens/github/password#GITHUB_TOKEN
+CTX_META=bw://docker/config#DOCKER_CONFIG
 ```
 
-The prefix is stripped and the remainder is lowercased to form the store name: `KCTX_PROD` → `prod`.
+- The same group name can appear on multiple lines — all entries belong to that group
+- The same URI can appear in multiple groups — it is fetched once per resolve (BW folder cache)
+- Group names are lowercased: `CTX_PROD` → group `prod`
+
+**Reserved group name: `meta`**
+`CTX_META` entries are a persistent baseline loaded on every `envoke switch`. They cannot be switched away from. If a group entry collides with a META entry, the group wins with a warning.
+
+**`ENVOKE_DEFAULT_GROUP`**
+Consumed by envoke during resolve, not exported as an env var. Auto-switches to the named group after all secrets are fetched:
+
+```bash
+ENVOKE_DEFAULT_GROUP=prod
+```
+
+### Built-in content validators
+
+When the `#ENVVAR` fragment matches a known name, envoke validates the secret content before writing it to a tmpfile:
+
+| Fragment | Validation |
+|---|---|
+| `#KUBECONFIG` | must contain `apiVersion` |
+| `#TALOSCONFIG` | must contain `context:` |
+| `#AWS_SHARED_CREDENTIALS_FILE` | must contain `[default]` or `[profile ` |
+| `#DOCKER_CONFIG` | must be valid JSON |
+| anything else | no validation — written as-is |
+
+### Migration from KCTX_
+
+The old `KCTX_<name>=bw://...` syntax is no longer supported. If an entry with a `KCTX_` prefix is encountered, envoke prints a migration error and exits. Migrate to `CTX_`:
+
+```bash
+# Before
+KCTX_PROD=bw://kubernetes/prod-cluster
+
+# After
+CTX_PROD=bw://kubernetes/prod#KUBECONFIG
+```
 
 ---
 
@@ -62,7 +103,7 @@ When shell-init is active:
 
 | Event | Action | Linux | macOS |
 |-------|--------|-------|-------|
-| Shell exit | Unload secrets, clear cache, kill watcher | ✓ | ✓ |
+| Shell exit | Unload secrets, remove context tmpfiles, clear cache | ✓ | ✓ |
 | Screen lock | Unset loaded variables in open shells | ✓ | ✗ |
 | System sleep | Clear cache — full re-auth required on wake | ✓ | ✓ (after wake) |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,25 +2,37 @@
 
 ## envoke resolve
 
-Resolves a `.env` file, exporting secrets as shell variables and loading kubeconfig directives into the named store.
+Resolves a `.env` file, exporting secrets as shell variables and writing context files to secure tmpfiles.
 
 ```bash
-envoke resolve           # resolves .env in current directory
-envoke resolve prod.env  # resolves a specific file
+eval "$(envoke resolve)"          # resolves .env in current directory
+eval "$(envoke resolve prod.env)" # resolves a specific file
 ```
 
-Output must be evaluated by your shell. With shell-init active this is automatic:
+With [shell-init](install.md#shell-integration) active, the `eval` is handled automatically.
+
+**Secret references** are resolved from Bitwarden (or other configured providers) and exported as env vars:
 
 ```bash
-envoke resolve .env
-# secrets are now in your environment
-# KCTX_* entries are loaded; use envoke switch <name> to activate one
+DB_PASSWORD=bw://myapp/db
+API_KEY=bw://myapp/api/field:key
 ```
 
-Without shell-init:
+**CTX_ entries** write a secret to a tmpfile in `/dev/shm` and export an env var pointing at it. The `#ENVVAR` fragment determines which env var to set — envoke does not care what the file contains or what tool reads it:
 
 ```bash
-eval "$(envoke resolve .env)"
+CTX_PROD=bw://k8s/prod#KUBECONFIG
+CTX_PROD=bw://talos/prod#TALOSCONFIG
+CTX_META=bw://aws/shared#AWS_SHARED_CREDENTIALS_FILE
+CTX_META=bw://tokens/github/password#GITHUB_TOKEN
+```
+
+`CTX_META` entries form a persistent baseline that is re-applied on every `envoke switch`. Any other `CTX_<GROUP>` name is a switchable group.
+
+**ENVOKE_DEFAULT_GROUP** auto-switches to a group after resolve, so no second `eval` is needed:
+
+```bash
+ENVOKE_DEFAULT_GROUP=prod
 ```
 
 **Flags:**
@@ -30,6 +42,45 @@ eval "$(envoke resolve .env)"
 | `--file`, `-f` | Path to .env file | `.env` |
 | `--shell` | Shell type for trap generation: `bash`, `zsh`, `fish` | `bash` |
 | `--force` | Bypass terminal check and print exports to terminal | `false` |
+
+---
+
+## envoke switch
+
+Switches to a named context group. All env vars from the previous group are unset, the META baseline is re-applied, and the new group's env vars are exported — pointing at already-written tmpfiles. No provider calls are made.
+
+```bash
+eval "$(envoke switch prod)"
+eval "$(envoke switch staging)"
+```
+
+`envoke switch meta` is rejected — META is always active and cannot be switched to directly.
+
+With shell-init active, the `eval` is handled automatically.
+
+---
+
+## envoke status
+
+Shows loaded env vars, context groups, and the active variable summary.
+
+```bash
+envoke status
+```
+
+---
+
+## envoke unload
+
+Unsets all variables exported by `envoke resolve` and removes all context tmpfiles.
+
+```bash
+eval "$(envoke unload)"
+```
+
+With shell-init active, the `eval` is handled automatically.
+
+---
 
 ## envoke exec
 
@@ -48,6 +99,8 @@ The resolved variables are injected into the subprocess environment only — the
 |------|-------------|---------|
 | `--env`, `-e` | Path to .env file | `.env` |
 
+---
+
 ## envoke yaml
 
 Resolves `bw://` references inside a YAML file and prints the result.
@@ -63,63 +116,17 @@ envoke yaml config.yaml --key database.password   # extract a single value
 |------|-------------|---------|
 | `--key` | Dot-notation key to extract (e.g. `database.password`) | — |
 
-## envoke load
-
-Fetches a kubeconfig from Bitwarden and caches it under a local name.
-
-```bash
-envoke load prod bw://kubernetes/prod-cluster
-envoke load dev bw://collection:k8s/dev-cluster
-```
-
-Names must match `[a-zA-Z0-9._-]+`.
-
-## envoke switch
-
-Activates a named kubeconfig by setting `KUBECONFIG` in your shell.
-
-```bash
-envoke switch prod
-envoke switch staging bw://k8s/staging   # fetch on the fly if not pre-loaded
-```
-
-Output must be evaluated. With shell-init active this is automatic:
-
-```bash
-envoke switch prod
-```
-
-Without shell-init:
-
-```bash
-eval "$(envoke switch prod)"
-```
-
-## envoke unload
-
-Unsets all variables exported by `envoke resolve` and clears `KUBECONFIG` if it was set by envoke.
-
-```bash
-envoke unload
-```
-
-Output must be evaluated. With shell-init active this is automatic.
-
-## envoke status
-
-Shows tracked env vars, current `KUBECONFIG`, and named kubeconfigs in the local store.
-
-```bash
-envoke status
-```
+---
 
 ## envoke clear-cache
 
-Removes the stored Bitwarden session and all kubeconfig files from the secure cache directory (`/run/user/<uid>`, `/dev/shm`, or `/tmp`).
+Removes the stored Bitwarden session and all managed tmpfiles from the secure cache directory (`/run/user/<uid>`, `/dev/shm`, or `/tmp`).
 
 ```bash
 envoke clear-cache
 ```
+
+---
 
 ## envoke shell-init
 
@@ -137,6 +144,8 @@ envoke shell-init --shell fish
 | `--shell` | Shell type: `bash`, `zsh`, `fish` | `bash` |
 | `--force` | Bypass terminal check (for scripting) | `false` |
 
+---
+
 ## envoke config
 
 Shows configuration documentation. Use `--init` to write a commented default config file.
@@ -149,9 +158,27 @@ envoke config --init --force    # overwrite existing config file
 
 See [Configuration](config.md) for the full config reference.
 
+---
+
 ## envoke watch
 
 Background daemon that watches for screen lock and sleep events. Normally started automatically by shell-init — you do not need to run this manually.
 
-On lock: secret variables are unloaded from open shells and managed kubeconfig tempfiles are removed. (Linux only — screen lock detection is not implemented on macOS. See [Known limitations](limitations.md).)  
+On lock: secret variables are unloaded from open shells and context tmpfiles are removed. (Linux only — screen lock detection is not implemented on macOS. See [Known limitations](limitations.md).)
 On sleep: all caches are cleared, requiring full re-authentication after wake.
+
+---
+
+## envoke load *(deprecated)*
+
+`envoke load` has been removed. Use `CTX_` entries in your `.env` file instead:
+
+```bash
+# Before
+envoke load prod bw://kubernetes/prod-cluster
+
+# After — add to .env
+CTX_PROD=bw://kubernetes/prod#KUBECONFIG
+```
+
+Then `eval "$(envoke resolve .env)"` and `eval "$(envoke switch prod)"`.

--- a/internal/ctx/entry.go
+++ b/internal/ctx/entry.go
@@ -1,0 +1,106 @@
+package ctx
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ContextEntry represents a single CTX_<GROUP>=<uri>#<ENVVAR> directive.
+type ContextEntry struct {
+	Group       string `json:"group"`
+	EnvVar      string `json:"env_var"`
+	SourceURI   string `json:"source_uri"`
+	TmpfilePath string `json:"tmpfile_path,omitempty"`
+}
+
+// IsCTXDirective returns true if the key has a CTX_ prefix.
+func IsCTXDirective(key string) bool {
+	return strings.HasPrefix(key, "CTX_")
+}
+
+// IsKCTXDirective returns true if the key has a KCTX_ prefix (legacy/deprecated).
+func IsKCTXDirective(key string) bool {
+	return strings.HasPrefix(key, "KCTX_")
+}
+
+// MigrationError returns a clear error for bare KCTX_ entries pointing users to
+// the new CTX_ syntax with a URI fragment.
+func MigrationError(key, value string) error {
+	group := strings.ToUpper(strings.TrimPrefix(key, "KCTX_"))
+	return fmt.Errorf(
+		"KCTX_ entries are no longer supported\n\n"+
+			"Migrate %s=%s to the new syntax:\n\n"+
+			"  CTX_%s=%s#KUBECONFIG\n\n"+
+			"Then run: envoke resolve",
+		key, value,
+		group, value,
+	)
+}
+
+// ParseContextEntry parses a CTX_<GROUP>=<uri>#<ENVVAR> raw entry.
+// Returns an error if the fragment (#ENVVAR) is missing or malformed.
+// Group name "meta" is valid here — rejection of "envoke switch meta" is in the switch command.
+func ParseContextEntry(key, value string) (ContextEntry, error) {
+	if !IsCTXDirective(key) {
+		return ContextEntry{}, fmt.Errorf("not a CTX_ directive: %s", key)
+	}
+	group := strings.ToLower(strings.TrimPrefix(key, "CTX_"))
+	if group == "" {
+		return ContextEntry{}, fmt.Errorf("CTX_ directive has empty group name: %s", key)
+	}
+
+	hashIdx := strings.LastIndex(value, "#")
+	if hashIdx < 0 || hashIdx == len(value)-1 {
+		return ContextEntry{}, fmt.Errorf(
+			"%s=%s is missing the #ENVVAR fragment\n\n"+
+				"The fragment declares which env var the secret is written to:\n\n"+
+				"  %s=%s#KUBECONFIG\n\n"+
+				"See: envoke resolve --help",
+			key, value, key, value,
+		)
+	}
+
+	sourceURI := value[:hashIdx]
+	envVar := value[hashIdx+1:]
+	if envVar == "" {
+		return ContextEntry{}, fmt.Errorf("%s=%s: env var name after # must not be empty", key, value)
+	}
+	if sourceURI == "" {
+		return ContextEntry{}, fmt.Errorf("%s=%s: source URI before # must not be empty", key, value)
+	}
+
+	return ContextEntry{
+		Group:     group,
+		EnvVar:    envVar,
+		SourceURI: sourceURI,
+	}, nil
+}
+
+// ValidateContent validates secret content against built-in rules for known
+// env var names. Unknown env var names get a no-op validator — content is
+// written as-is without validation.
+func ValidateContent(envVar string, content []byte) error {
+	s := string(content)
+	switch envVar {
+	case "KUBECONFIG":
+		if !strings.Contains(s, "apiVersion") {
+			return fmt.Errorf("content for KUBECONFIG does not look like a kubeconfig (missing 'apiVersion')")
+		}
+	case "TALOSCONFIG":
+		if !strings.Contains(s, "context:") {
+			return fmt.Errorf("content for TALOSCONFIG does not look like a talosconfig (missing 'context:')")
+		}
+	case "AWS_SHARED_CREDENTIALS_FILE":
+		if !strings.Contains(s, "[default]") && !strings.Contains(s, "[profile ") {
+			return fmt.Errorf("content for AWS_SHARED_CREDENTIALS_FILE does not look like an AWS credentials file (missing '[default]' or '[profile ')")
+		}
+	case "DOCKER_CONFIG":
+		var js interface{}
+		if err := json.Unmarshal(content, &js); err != nil {
+			return fmt.Errorf("content for DOCKER_CONFIG is not valid JSON: %w", err)
+		}
+	}
+	// Unknown env var names: no validation, written as-is.
+	return nil
+}

--- a/internal/ctx/state.go
+++ b/internal/ctx/state.go
@@ -1,0 +1,95 @@
+package ctx
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/opalbolt/envoke/internal/securedir"
+)
+
+// GroupsState persists the full CTX group resolution across envoke subcommands.
+// It is written to securedir after `envoke resolve` and read by `envoke switch`,
+// `envoke status`, and `envoke unload` — no provider calls are needed after resolve.
+type GroupsState struct {
+	// Groups maps lowercase group name → ordered slice of context entries.
+	// The META baseline is stored under the reserved key "meta".
+	Groups map[string][]ContextEntry `json:"groups"`
+	// ActiveGroup is the group currently exported into the shell session.
+	// Empty string means no group has been switched to yet.
+	ActiveGroup string `json:"active_group"`
+}
+
+// statePath returns the on-disk path for the CTX state file.
+func statePath(uid string) string {
+	return filepath.Join(securedir.Dir(), "envoke-"+uid+"-ctx-state.json")
+}
+
+// SaveState writes the full group state to disk with 0600 permissions.
+func SaveState(uid string, st GroupsState) error {
+	data, err := json.Marshal(st)
+	if err != nil {
+		return fmt.Errorf("ctx state: marshal: %w", err)
+	}
+	path := statePath(uid)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("ctx state: write %s: %w", path, err)
+	}
+	return nil
+}
+
+// LoadState reads the group state from disk.
+// Returns an empty GroupsState (and no error) if the file does not exist yet.
+func LoadState(uid string) (GroupsState, error) {
+	path := statePath(uid)
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return GroupsState{Groups: make(map[string][]ContextEntry)}, nil
+	}
+	if err != nil {
+		return GroupsState{}, fmt.Errorf("ctx state: read %s: %w", path, err)
+	}
+	var st GroupsState
+	if err := json.Unmarshal(data, &st); err != nil {
+		return GroupsState{}, fmt.Errorf("ctx state: unmarshal: %w", err)
+	}
+	if st.Groups == nil {
+		st.Groups = make(map[string][]ContextEntry)
+	}
+	return st, nil
+}
+
+// ClearState removes the state file and all tmpfiles referenced in it.
+// Called by `envoke unload`. Best-effort on individual tmpfile removal.
+func ClearState(uid string) error {
+	st, err := LoadState(uid)
+	if err != nil {
+		// Best-effort: just remove the state file even if we can't parse it.
+		_ = os.Remove(statePath(uid))
+		return nil
+	}
+	for _, entries := range st.Groups {
+		for _, e := range entries {
+			if e.TmpfilePath != "" {
+				_ = os.Remove(e.TmpfilePath)
+			}
+		}
+	}
+	path := statePath(uid)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("ctx state: remove %s: %w", path, err)
+	}
+	return nil
+}
+
+// SetActiveGroup updates only the active group field in the state file.
+// Used by switchCmd to track which group is currently exported.
+func SetActiveGroup(uid, group string) error {
+	st, err := LoadState(uid)
+	if err != nil {
+		return err
+	}
+	st.ActiveGroup = group
+	return SaveState(uid, st)
+}

--- a/internal/kubeconfig/tmpfile.go
+++ b/internal/kubeconfig/tmpfile.go
@@ -29,15 +29,19 @@ func NewTempFile(prefix string) (*os.File, error) {
 	return f, nil
 }
 
-// IsManaged reports whether path looks like a kctx-managed kubeconfig file
-// (i.e. a "kctx-" prefixed file in the secure directory).
+// IsManaged reports whether path is a file managed by envoke — i.e. it lives
+// inside the platform-appropriate secure directory.
+// The old kctx- prefix check is intentionally dropped: CTX_ tmpfiles use the
+// envoke-ctx- prefix, named store entries use kctx-kc-, and future prefixes
+// should all be recognised without updating this function.
 func IsManaged(path string) bool {
 	dir := filepath.Dir(path)
 	base := filepath.Base(path)
 	if dir != securedir.Dir() {
 		return false
 	}
-	return len(base) > 5 && base[:5] == "kctx-"
+	// Any non-empty filename inside securedir is envoke-managed.
+	return base != ""
 }
 
 // IsManagedTemp reports whether path is a kctx-managed kubeconfig tmpfile

--- a/internal/providers/bitwarden/client.go
+++ b/internal/providers/bitwarden/client.go
@@ -381,11 +381,15 @@ func extractField(item map[string]interface{}, fieldSpec string) (string, error)
 	switch fieldSpec {
 	case "password":
 		login, _ := item["login"].(map[string]interface{})
-		if login == nil {
-			return "", fmt.Errorf("item has no login")
+		if login != nil {
+			val, _ := login["password"].(string)
+			return val, nil
 		}
-		val, _ := login["password"].(string)
-		return val, nil
+		// No login field — fall back to secure note body if present.
+		if notes, _ := item["notes"].(string); notes != "" {
+			return notes, nil
+		}
+		return "", fmt.Errorf("item has no login and no notes; specify /note or /field:<name> explicitly")
 	case "username":
 		login, _ := item["login"].(map[string]interface{})
 		if login == nil {


### PR DESCRIPTION
## What

Implements #23 — generic context/file injection via `CTX_` environment groups, replacing the `KCTX_`/`envoke load` pattern with a provider-agnostic, type-agnostic approach.

## Problem

`KCTX_` was hardcoded for Kubernetes kubeconfigs. The pattern it implemented — fetch a secret, write it to a tmpfile, export an env var pointing at it — is broadly useful but previously only worked for `KUBECONFIG`.

## Solution

The URI fragment declares the target env var. Envoke doesn't care what the file contains or which tool reads it:

```dotenv
CTX_PROD=bw://k8s/prod#KUBECONFIG
CTX_PROD=bw://talos/prod#TALOSCONFIG
CTX_META=bw://aws/shared#AWS_SHARED_CREDENTIALS_FILE
CTX_META=bw://tokens/github/password#GITHUB_TOKEN
```

`envoke resolve` fetches all groups eagerly. `envoke switch` is instant — no provider calls, purely local state.

## Changes

### New package: `internal/ctx`
- `ContextEntry` — `group/envVar/sourceURI/tmpfilePath`
- `ParseContextEntry` — splits `CTX_PROD=bw://k8s/prod#KUBECONFIG` into parts
- `ValidateContent` — built-in validators for `KUBECONFIG`, `TALOSCONFIG`, `AWS_SHARED_CREDENTIALS_FILE`, `DOCKER_CONFIG`; unknown fragments pass through as-is
- `GroupsState` — JSON state persisted to `securedir` (0600) after resolve; read by switch/status/unload with no provider calls

### `cmd/envoke/main.go`
- `resolveCmd`: `CTX_` partition, eager fetch → tmpfile → save state; emits META baseline; `ENVOKE_DEFAULT_GROUP` auto-switches after resolve
- `switchCmd`: fully rewritten — zero provider calls; rejects `meta`; unsets prev group, re-applies META, applies target with collision warning
- `statusCmd`: legacy Kubeconfig section removed; CTX groups section with `◆`/`●`/`○` indicators; new **Active context variables** summary showing env var → source group
- `unloadCmd`: cleans CTX tmpfiles and clears state
- `loadCmd`: deprecated — prints migration guidance and exits 1

### Bug fixes
- `bw` provider: bare `bw://folder/item` now falls back to secure note body when the item has no login field
- `IsManaged`: replaced prefix check (`kctx-`) with directory check — any file in `securedir` is envoke-managed, covering `envoke-ctx-` and future prefixes

### Docs
- `usage.md`, `reference.md`, `direnv.md` rewritten for CTX_ system
- KCTX_ migration guide in reference.md
- `envoke load` replaced with deprecation notice

## How to test

Test fixtures and a full step-by-step script live in `human-test/` (gitignored — contains real vault refs).

### Setup

Import `human-test/bw-import.json` into Bitwarden (**Tools → Import**), then paste the content files into each item's secure note body:

| Item | Field | File |
|---|---|---|
| `kubeconfig-prod` | Secure note | `human-test/content/kubeconfig-prod.yaml` |
| `kubeconfig-staging` | Secure note | `human-test/content/kubeconfig-staging.yaml` |
| `talosconfig-prod` | Secure note | `human-test/content/talosconfig-prod.yaml` |
| `aws-credentials-shared` | Secure note | `human-test/content/aws-credentials-shared.ini` |
| `docker-config` | Secure note | `human-test/content/docker-config.json` |
| `github-token` | Password field | any string |

### Happy path

```bash
# Resolve — fetches all groups, auto-switches to prod via ENVOKE_DEFAULT_GROUP
eval "$(envoke resolve human-test/.env)"
envoke status

# Verify each file type is accessible
cat $KUBECONFIG                  # prod kubeconfig YAML (apiVersion present)
cat $TALOSCONFIG                 # prod talosconfig YAML (context: present)
cat $AWS_SHARED_CREDENTIALS_FILE # [default] + [profile prod]
cat $DOCKER_CONFIG               # valid JSON
echo $GITHUB_TOKEN               # token string (META, no validation)

# Switch — TALOSCONFIG unset, KUBECONFIG flips, META persists
eval "$(envoke switch staging)"
echo $TALOSCONFIG                # empty — not in staging group
echo $GITHUB_TOKEN               # still set — META survives switch

# Switch back
eval "$(envoke switch prod)"
echo $TALOSCONFIG                # restored

# Unload — all vars unset, all tmpfiles removed
eval "$(envoke unload)"
ls /run/user/$(id -u)/envoke-ctx-*.tmp 2>/dev/null  # no files
```

### Error paths

```bash
envoke switch meta         # rejected: 'meta' is not a switchable group
envoke load prod bw://x   # deprecated: prints migration guidance

# KCTX_ migration error — add to .env temporarily:
# KCTX_PROD=bw://human-test/kubeconfig-prod
eval "$(envoke resolve human-test/.env)"   # clear error with CTX_ suggestion

# Unknown ENVOKE_DEFAULT_GROUP — set in .env temporarily:
# ENVOKE_DEFAULT_GROUP=doesnotexist
eval "$(envoke resolve human-test/.env)"   # warning, resolve continues

# META collision warning — add to .env temporarily:
# CTX_STAGING=bw://human-test/aws-credentials-shared#AWS_SHARED_CREDENTIALS_FILE
eval "$(envoke resolve human-test/.env)"
eval "$(envoke switch staging)"            # ⚠ collision warning on stderr
```

## Acceptance criteria

- [x] `envoke resolve` eagerly fetches all `CTX_*` groups and writes each secret to a tmpfile
- [x] `envoke resolve` registers all groups in state so `envoke switch` needs no provider calls
- [x] `CTX_META=` entries loaded as persistent baseline, re-applied on every switch
- [x] `envoke switch prod` is instant — no provider calls, purely local
- [x] `envoke switch prod` unloads active context env vars, re-applies META, loads prod group
- [x] `envoke switch staging` cleanly replaces prod — no leftover prod env vars
- [x] Collision between META and group entry emits loud warning — group wins
- [x] `envoke switch meta` rejected with clear error
- [x] `envoke unload` removes all active tmpfiles and unsets all context env vars including META
- [x] `envoke status` shows META separately from active/inactive groups
- [x] Duplicate `CTX_PROD=` entries collected as a group — not last-write
- [x] `.env` file remains directly sourceable by shell
- [x] URI fragment determines target env var; unknown fragments export as-is
- [x] `envoke load` removed; prints deprecation error pointing to `resolve`
- [x] Bare `KCTX_=bw://` entries rejected with clear migration message