### PR TITLE
fix(flake): pin go_1_25 in buildGoModule and devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,7 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        go = pkgs.go_1_25;
 
         # Single source of truth for the version number — kept in sync with git tags.
         # `git tag v0.2.0 && echo -n 0.2.0 > VERSION` is the release workflow.
@@ -35,6 +36,7 @@
           src = ./.;
           vendorHash = "sha256-LUCRrwakaITrnME5a0tiAp0jsMJQKPtIV8Y8LLwA3LI=";
           subPackages = [ "cmd/envoke" ];
+          inherit go;
           ldflags = [
             "-s" "-w"
             "-X ${versionPkg}.Version=${nixVersion}"
@@ -58,8 +60,9 @@
         # `nix develop` — provides the full Go toolchain and dev tools.
         # Run make targets directly: make build, make test-race, make lint, etc.
         devShells.default = pkgs.mkShell {
-          packages = with pkgs; [
+          packages = [
             go
+          ] ++ (with pkgs; [
             gotools  # goimports, etc.
             gopls
             go-tools  # staticcheck
@@ -68,7 +71,7 @@
             gosec
             gnumake
             shellcheck
-          ];
+          ]);
 
           shellHook = ''
             export CGO_ENABLED=0


### PR DESCRIPTION
## Problem

Installing envoke from the flake failed when the consumer's nixpkgs-unstable snapshot shipped a Go version behind the `go` directive in `go.mod`:

```
go: go.mod requires go >= 1.25.10 (running go 1.25.9; GOTOOLCHAIN=local)
```

`buildGoModule` was using bare `pkgs.go` — whatever version nixpkgs happened to have — making the build sensitive to the consumer's nixpkgs pin.

## Fix

Pin `pkgs.go_1_25` once in the `let` block and thread it into both `buildGoModule` (via `inherit go`) and `devShells`. Both the package build and the dev shell now use the same explicit toolchain.

## Testing

```bash
nix flake check --no-build   # evaluates cleanly
nix build                    # builds with pinned go_1_25
```