### PR TITLE
build(nix): switch to gomod2nix and nixos-unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,18 +18,57 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gomod2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770585520,
+        "narHash": "sha256-yBz9Ozd5Wb56i3e3cHZ8WcbzCQ9RlVaiW18qDYA/AzA=",
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "rev": "1201ddd1279c35497754f016ef33d5e060f3da8d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779467186,
-        "narHash": "sha256-nOesoDCiXcUftqbRBMz9tt4blI5PvljMWbm3kuCA+0s=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b77b3de8775677f84492abe84635f87b0e153f0f",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -37,10 +76,26 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "gomod2nix": "gomod2nix",
         "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,7 @@
         devShells.default = pkgs.mkShell {
           packages = [
             go
-            gomod2nix.packages.${system}.gomod2nix
+            gomod2nix.packages.${system}.default
           ] ++ (with pkgs; [
             gotools       # goimports, etc.
             gopls

--- a/flake.nix
+++ b/flake.nix
@@ -2,14 +2,20 @@
   description = "envoke — unified secret environment loader (env vars and kubeconfigs)";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    gomod2nix = {
+      url = "github:nix-community/gomod2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils, gomod2nix }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        inherit (gomod2nix.legacyPackages.${system}) mkGoEnv buildGoApplication;
+
         go = pkgs.go_1_25;
 
         # Single source of truth for the version number — kept in sync with git tags.
@@ -30,11 +36,11 @@
           else
             "${builtins.substring 0 4 raw}-${builtins.substring 4 2 raw}-${builtins.substring 6 2 raw}T${builtins.substring 8 2 raw}:${builtins.substring 10 2 raw}:${builtins.substring 12 2 raw}Z";
 
-        envoke = pkgs.buildGoModule {
+        envoke = buildGoApplication {
           pname = "envoke";
           version = releaseVersion;
           src = ./.;
-          vendorHash = "sha256-LUCRrwakaITrnME5a0tiAp0jsMJQKPtIV8Y8LLwA3LI=";
+          modules = ./gomod2nix.toml;
           subPackages = [ "cmd/envoke" ];
           inherit go;
           ldflags = [
@@ -62,10 +68,11 @@
         devShells.default = pkgs.mkShell {
           packages = [
             go
+            gomod2nix.packages.${system}.gomod2nix
           ] ++ (with pkgs; [
-            gotools  # goimports, etc.
+            gotools       # goimports, etc.
             gopls
-            go-tools  # staticcheck
+            go-tools      # staticcheck
             goreleaser
             govulncheck
             gosec
@@ -83,4 +90,3 @@
       }
     );
 }
-

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -1,0 +1,86 @@
+schema = 3
+
+[mod]
+  [mod.'github.com/aymanbagabas/go-osc52/v2']
+    version = 'v2.0.1'
+    hash = 'sha256-6Bp0jBZ6npvsYcKZGHHIUSVSTAMEyieweAX2YAKDjjg='
+
+  [mod.'github.com/charmbracelet/colorprofile']
+    version = 'v0.2.3-0.20250311203215-f60798e515dc'
+    hash = 'sha256-D9E/bMOyLXAUVOHA1/6o3i+vVmLfwIMOWib6sU7A6+Q='
+
+  [mod.'github.com/charmbracelet/lipgloss']
+    version = 'v1.1.0'
+    hash = 'sha256-RHsRT2EZ1nDOElxAK+6/DC9XAaGVjDTgPvRh3pyCfY4='
+
+  [mod.'github.com/charmbracelet/x/ansi']
+    version = 'v0.8.0'
+    hash = 'sha256-/YyDkGrULV2BtnNk3ojeSl0nUWQwIfIdW7WJuGbAZas='
+
+  [mod.'github.com/charmbracelet/x/cellbuf']
+    version = 'v0.0.13-0.20250311204145-2c3ea96c31dd'
+    hash = 'sha256-XAhCOt8qJ2vR77lH1ez0IVU1/2CaLTq9jSmrHVg5HHU='
+
+  [mod.'github.com/charmbracelet/x/term']
+    version = 'v0.2.1'
+    hash = 'sha256-VBkCZLI90PhMasftGw3403IqoV7d3E5WEGAIVrN5xQM='
+
+  [mod.'github.com/godbus/dbus/v5']
+    version = 'v5.2.2'
+    hash = 'sha256-j+LicPlXcB1R3oVFPa8cd4yVJLpBx+ca5gXmHqOJSN8='
+
+  [mod.'github.com/inconshreveable/mousetrap']
+    version = 'v1.1.0'
+    hash = 'sha256-XWlYH0c8IcxAwQTnIi6WYqq44nOKUylSWxWO/vi+8pE='
+
+  [mod.'github.com/kr/pretty']
+    version = 'v0.3.1'
+    hash = 'sha256-DlER7XM+xiaLjvebcIPiB12oVNjyZHuJHoRGITzzpKU='
+
+  [mod.'github.com/lucasb-eyer/go-colorful']
+    version = 'v1.2.0'
+    hash = 'sha256-Gg9dDJFCTaHrKHRR1SrJgZ8fWieJkybljybkI9x0gyE='
+
+  [mod.'github.com/mattn/go-isatty']
+    version = 'v0.0.20'
+    hash = 'sha256-qhw9hWtU5wnyFyuMbKx+7RB8ckQaFQ8D+8GKPkN3HHQ='
+
+  [mod.'github.com/mattn/go-runewidth']
+    version = 'v0.0.16'
+    hash = 'sha256-NC+ntvwIpqDNmXb7aixcg09il80ygq6JAnW0Gb5b/DQ='
+
+  [mod.'github.com/muesli/termenv']
+    version = 'v0.16.0'
+    hash = 'sha256-hGo275DJlyLtcifSLpWnk8jardOksdeX9lH4lBeE3gI='
+
+  [mod.'github.com/rivo/uniseg']
+    version = 'v0.4.7'
+    hash = 'sha256-rDcdNYH6ZD8KouyyiZCUEy8JrjOQoAkxHBhugrfHjFo='
+
+  [mod.'github.com/spf13/cobra']
+    version = 'v1.10.2'
+    hash = 'sha256-nbRCTFiDCC2jKK7AHi79n7urYCMP5yDZnWtNVJrDi+k='
+
+  [mod.'github.com/spf13/pflag']
+    version = 'v1.0.10'
+    hash = 'sha256-uDPnWjHpSrzXr17KEYEA1yAbizfcsfo5AyztY2tS6ZU='
+
+  [mod.'github.com/xo/terminfo']
+    version = 'v0.0.0-20220910002029-abceb7e1c41e'
+    hash = 'sha256-GyCDxxMQhXA3Pi/TsWXpA8cX5akEoZV7CFx4RO3rARU='
+
+  [mod.'golang.org/x/sys']
+    version = 'v0.42.0'
+    hash = 'sha256-LhNedvUEJbPYyR6EoU91rfOr3DBBoauLOcMcyqghEos='
+
+  [mod.'golang.org/x/term']
+    version = 'v0.41.0'
+    hash = 'sha256-EQVhfumFhP5O1Qo2PxWpESwC4EnIpfyjMIlMWbobAUQ='
+
+  [mod.'gopkg.in/check.v1']
+    version = 'v1.0.0-20190902080502-41f04d3bba15'
+    hash = 'sha256-Xl5gjoqU26M+Yxm6Xok5VHVpYT5hItwsN7d2Wj9L020='
+
+  [mod.'gopkg.in/yaml.v3']
+    version = 'v3.0.1'
+    hash = 'sha256-FqL9TKYJ0XkNwJFnq9j0VvJ5ZUU1RvH/52h/f5bkYAU='


### PR DESCRIPTION
## Problem

\`nix build\` and \`nix profile install\` were failing because \`nixos-25.11\` ships \`go_1_25\` at version 1.25.9, while \`go.mod\` declares \`go 1.25.10\` as the minimum. The Nix sandbox has no network access, so it cannot download the missing toolchain — the build dies with \`go: go.mod requires go >= 1.25.10 (running go 1.25.9; GOTOOLCHAIN=local)\`.

## Changes

- \`flake.nix\` — switch nixpkgs input from \`nixos-25.11\` to \`nixos-unstable\` (provides \`go_1_25\` at 1.25.10, satisfying the \`go.mod\` minimum)
- \`flake.nix\` — replace \`buildGoModule\` + \`vendorHash\` with \`gomod2nix\`'s \`buildGoApplication\` + \`gomod2nix.toml\`
- \`flake.nix\` — add \`gomod2nix\` as a flake input (follows nixpkgs) and expose the \`gomod2nix\` CLI in \`devShells.default\`
- \`gomod2nix.toml\` — new committed dependency lockfile for the Nix build
- \`flake.lock\` — updated for new inputs

## Why

Switching to \`nixos-unstable\` was the minimal fix for the version mismatch — \`go.mod\` intentionally pins to \`1.25.10\` (not a loose \`go 1.25\`) so \`govulncheck\` correctly scopes vulnerability checks to the actual patch version in use. Relaxing the \`go.mod\` directive would have silenced the Nix error but caused govulncheck to potentially flag already-patched CVEs as open.

\`buildGoModule\` requires recalculating \`vendorHash\` on every dependency change, which is a constant friction point. \`gomod2nix\` replaces this with a committed \`gomod2nix.toml\` that is regenerated by running \`gomod2nix\` in the dev shell — no hash guessing, no \`lib.fakeHash\` dance.

## How to verify

\`\`\`bash
# Build locally from the branch
git checkout build/nix-gomod2nix-unstable
nix build
./result/bin/envoke --version

# Enter dev shell — gomod2nix should be available
nix develop
gomod2nix --help
\`\`\`

After a \`go get\` / \`go mod tidy\`, regenerate the lockfile with:

\`\`\`bash
gomod2nix
git add gomod2nix.toml
\`\`\`